### PR TITLE
[JENKINS-34281] Better robustness against missing queue items

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
@@ -37,6 +37,7 @@ import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.util.FormValidation;
+import java.io.Serializable;
 import javax.annotation.CheckForNull;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -58,7 +59,9 @@ import java.util.Set;
  *     }
  * </pre>
  */
-public final class ExecutorStep extends AbstractStepImpl {
+public final class ExecutorStep extends AbstractStepImpl implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final @CheckForNull String label;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -139,6 +139,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         // See if we are still running, or scheduled to run. Cf. stop logic above.
         for (Queue.Item item : Queue.getInstance().getItems()) {
             if (item.task instanceof PlaceholderTask && ((PlaceholderTask) item.task).context.equals(getContext())) {
+                LOGGER.log(FINE, "Queue item for node block in {0} is still waiting after reload", run);
                 return;
             }
         }
@@ -148,13 +149,15 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 for (Executor e : c.getExecutors()) {
                     Queue.Executable exec = e.getCurrentExecutable();
                     if (exec instanceof PlaceholderTask.PlaceholderExecutable && ((PlaceholderTask.PlaceholderExecutable) exec).getParent().context.equals(getContext())) {
+                        LOGGER.log(FINE, "Node block in {0} is running on {1} after reload", new Object[] {run, c.getName()});
                         return;
                     }
                 }
             }
         }
-        if (step == null) {
-            return; // compatibility: used to be transient
+        if (step == null) { // compatibility: used to be transient
+            listener.getLogger().println("Queue item for node block in " + run.getFullDisplayName() + " is missing (perhaps JENKINS-34281), but cannot reschedule");
+            return;
         }
         listener.getLogger().println("Queue item for node block in " + run.getFullDisplayName() + " is missing (perhaps JENKINS-34281); rescheduling");
         try {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/Messages.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright 2016 CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+ExecutorStepExecution.queue_task_cancelled=Queue task was cancelled


### PR DESCRIPTION
[JENKINS-34281](https://issues.jenkins-ci.org/browse/JENKINS-34281) can mean that if a Pipeline build was running a `node` step but was waiting for an executor (not yet inside the block), after a restart the `Queue.Item` for the block goes missing. Without intervention, the build will just sit there quietly until interrupted.

- [X] work around JENKINS-34281
- [x] immediately fail the step if a queue item is deliberately canceled

@reviewbybees