### PR TITLE
[JENKINS-37121] Use WorkspaceList.record, not .acquire, when dehydrating a pickle

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
@@ -64,7 +64,7 @@ public class WorkspaceListLeasePickle extends Pickle {
                     return null;
                 }
                 FilePath fp = new FilePath(ch, path);
-                return c.getWorkspaceList().acquire(fp);
+                return c.getWorkspaceList().record(fp);
             }
             @Override public String toString() {
                 return "Relocking workspace named ‘" + path + "’ on computer named ‘" + slave + "’";

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
@@ -64,7 +64,14 @@ public class WorkspaceListLeasePickle extends Pickle {
                     return null;
                 }
                 FilePath fp = new FilePath(ch, path);
-                return c.getWorkspaceList().record(fp);
+                // Since there is no equivalent to Lock.tryLock for WorkspaceList (.record would work but throws AssertionError and swaps the holder):
+                WorkspaceList.Lease lease = c.getWorkspaceList().allocate(fp);
+                if (lease.path.equals(fp)) {
+                    return lease;
+                } else { // @2 or other variant, not what we expected to be able to lock without contention
+                    lease.release();
+                    throw new IllegalStateException("JENKINS-37121: something already locked " + fp);
+                }
             }
             @Override public String toString() {
                 return "Relocking workspace named ‘" + path + "’ on computer named ‘" + slave + "’";


### PR DESCRIPTION
[JENKINS-37121](https://issues.jenkins-ci.org/browse/JENKINS-37121)

The situation described in the issue is anomalous. It is better for `tryResolve` to fail immediately if the workspace was locked by something else, rather than call `acquire` and block a `Timer` thread indefinitely.

@reviewbybees