### PR TITLE
Allow extension of ExecutorStep

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
@@ -59,7 +59,7 @@ import java.util.Set;
  *     }
  * </pre>
  */
-public final class ExecutorStep extends AbstractStepImpl implements Serializable {
+public class ExecutorStep extends AbstractStepImpl implements Serializable {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
docker-slaves do offer pipeline `dockerNode()` and rely on a copy/paste of ExecutorStep|Execution. Not being final would allow to  rely on upstream code and benefits fixes and improvements made here