### PR TITLE
Testing behavior when a queue item is canceled while trying to resume a node block

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.support.pickles;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Executor;
 import hudson.model.Node;
@@ -91,6 +92,10 @@ public class ExecutorPickle extends Pickle {
                 if (!future.isDone()) {
                     // TODO JENKINS-26130 we might be able to detect that the item is blocked on an agent which has been deleted (not just offline), and abort ourselves
                     return null;
+                }
+
+                if (future.isCancelled()) {
+                    throw new AbortException("Queue item was canceled.");
                 }
 
                 Queue.Executable exec = future.get();

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.pickles;
+
+import hudson.model.Label;
+import hudson.model.Queue;
+import hudson.slaves.DumbSlave;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.durable_task.Messages;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class ExecutorPickleTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public RestartableJenkinsRule r = new RestartableJenkinsRule();
+
+    @Test public void canceledQueueItem() throws Exception {
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                DumbSlave s = r.j.createSlave(Label.get("remote"));
+                WorkflowJob p = r.j.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("node('remote') {semaphore 'wait'}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("wait/1", b);
+                r.j.jenkins.removeNode(s);
+            }
+        });
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                SemaphoreStep.success("wait/1", null);
+                WorkflowRun b = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
+                r.j.waitForMessage(hudson.model.Messages.Queue_WaitingForNextAvailableExecutor(), b);
+                r.j.assertLogContains(Messages.ExecutorPickle_waiting_to_resume(Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getFullDisplayName())), b);
+                Queue.Item[] items = Queue.getInstance().getItems();
+                assertEquals(1, items.length);
+                Queue.getInstance().cancel(items[0]);
+                r.j.waitForCompletion(b);
+                // Do not bother with assertBuildStatus; we do not really care whether it is ABORTED or FAILURE
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
Also improving the display of that behavior a bit.

Was attempting to reproduce a cryptic error from @cyrille-leclerc

```
Resuming build at … after Jenkins restart
Waiting to resume Unknown Pipeline node step: ???
Waiting to resume Unknown Pipeline node step: Waiting for next available executor
Waiting to resume Unknown Pipeline node step: Waiting for next available executor
Waiting to resume Unknown Pipeline node step: Waiting for next available executor
[Pipeline] End of Pipeline
java.io.IOException: Failed to load persisted workflow state
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:585)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$3.onSuccess(CpsFlowExecution.java:583)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$4$1.run(CpsFlowExecution.java:626)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:32)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:112)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: queue lost item #…
	at org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle$1.tryResolve(ExecutorPickle.java:86)
	at org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle$1.tryResolve(ExecutorPickle.java:71)
	at org.jenkinsci.plugins.workflow.support.pickles.TryRepeatedly$1.run(TryRepeatedly.java:91)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	... 3 more
Finished: FAILURE
```

but I cannot do so. The `queue lost item` condition does not occur. Also `Unknown Pipeline node step` is not used; the text is `part of p #1` as expected.

@reviewbybees