### PR TITLE
Run part details not exported via API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -62,6 +62,7 @@ import org.jenkinsci.plugins.workflow.support.actions.WorkspaceActionImpl;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 public class ExecutorStepExecution extends AbstractStepExecutionImpl {
@@ -479,7 +480,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
          * Occupies {@link Executor} while workflow uses this slave.
          */
         @ExportedBean
-        private final class PlaceholderExecutable implements ContinuableExecutable {
+        public final class PlaceholderExecutable implements ContinuableExecutable {
 
             @Override public void run() {
                 final TaskListener listener;
@@ -589,6 +590,23 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return PlaceholderTask.this;
             }
 
+            @Exported
+            public int getNumber() {
+                Run<?, ?> r = getParent().runForDisplay();
+                return r != null ? r.getNumber() : -1;
+            }
+
+            @Exported
+            public String getFullDisplayName() {
+                return getParent().getFullDisplayName();
+            }
+
+            @Exported
+            public String getDisplayName() {
+                return getParent().getDisplayName();
+            }
+
+            @Exported
             @Override public long getEstimatedDuration() {
                 return getParent().getEstimatedDuration();
             }
@@ -604,9 +622,18 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return Executor.of(this);
             }
 
-            @Restricted(NoExternalUse.class) // for Jelly and toString
+            @Exported @Restricted(NoExternalUse.class) // for Jelly and toString
             public String getUrl() {
-                return PlaceholderTask.this.getUrl(); // we hope this has a console.jelly
+                Run<?,?> r = runForDisplay();
+                if (r == null) {
+                    return "";
+                }
+                Jenkins j = Jenkins.getInstance();
+                String base = "";
+                if (j != null) {
+                    base = Util.removeTrailingSlash(j.getRootUrl()) + "/";
+                }
+                return base + r.getUrl();
             }
 
             @Override public String toString() {


### PR DESCRIPTION
When part of a workflow run is executing on a node, the corresponding run details are not available via the API (xml/json)

Without this patch, the run part cannot be identified by examining the API call's result.

This poses a problem for an integration such as python-jenkins where its server.get_running_builds()
queries each node to build up an array of builds. As a mininum, 'number' and 'url' are needed.

The plugin exposes this data already via Jelly in the Executor view.
