### PR TITLE
If an executor slot is orphaned, allow it to be manually cleared

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -570,8 +570,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             Executor masterExecutor = r.getExecutor();
                             if (masterExecutor != null) {
                                 masterExecutor.interrupt();
-                            } else { // ?
+                            } else { // anomalous state; perhaps build already aborted but this was left behind; let user manually cancel executor slot
                                 super.getExecutor().recordCauseOfInterruption(r, listener);
+                                completed(null);
                             }
                         }
                         @Override public boolean blocksRestart() {


### PR DESCRIPTION
@cyrille-leclerc came across a case where due to what seems to be massive corruption of build records on disk for unknown reasons, perhaps combined with https://github.com/jenkinsci/workflow-job-plugin/pull/26, a build was actually marked finished (no master flyweight executor, `ABORTED` status, etc.) yet it had a `PlaceholderExecutable` still occupying an executor slot, which could not be canceled. Inspection in `/script` showed that it was in this clause. Manually calling `.completed(null)` sufficed to clear the executor slot. No idea how to reproduce this situation, but it seems appropriate to do this cleanup.

@reviewbybees