### PR TITLE
[JENKINS-37324] Retain script argument to the batch/shell steps so we can retrieve it upon demand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -46,6 +46,7 @@ import jenkins.util.Timer;
 import org.jenkinsci.plugins.durabletask.Controller;
 import org.jenkinsci.plugins.durabletask.DurableTask;
 import org.jenkinsci.plugins.workflow.FilePathUtils;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -151,6 +152,11 @@ public abstract class DurableTaskStep extends AbstractStepImpl {
             encoding = step.encoding;
             returnStatus = step.returnStatus;
             node = FilePathUtils.getNodeName(ws);
+            if (step instanceof BatchScriptStep || step instanceof ShellStep)  {
+                FlowNode fn = getContext().get(FlowNode.class);
+                String script = (step instanceof BatchScriptStep) ? ((BatchScriptStep)step).getScript() : ((ShellStep)step).getScript();
+                fn.addAction(new ScriptArgumentAction(script));
+            }
             DurableTask task = step.task();
             if (returnStdout) {
                 task.captureOutput();

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
@@ -2,6 +2,8 @@ package org.jenkinsci.plugins.workflow.steps.durable_task;
 
 import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Stores argument info passed into the script so it can be inspected from the flow graph
  */
@@ -24,6 +26,7 @@ public class ScriptArgumentAction implements PersistentAction {
         return null;
     }
 
+    @CheckForNull
     public String getParam() {
         return this.param;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.workflow.steps.durable_task;
+
+import org.jenkinsci.plugins.workflow.actions.PersistentAction;
+
+/**
+ * Stores argument info passed into the script so it can be inspected from the flow graph
+ */
+public class ScriptArgumentAction implements PersistentAction {
+    private static final String actionName = "DurableTaskScript";
+    private final String param;
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return actionName;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    public String getParam() {
+        return this.param;
+    }
+
+    public ScriptArgumentAction(String param) {
+        this.param = param;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ScriptArgumentAction.java
@@ -9,7 +9,7 @@ import javax.annotation.CheckForNull;
  */
 public class ScriptArgumentAction implements PersistentAction {
     private static final String actionName = "DurableTaskScript";
-    private final String param;
+    private final String script;
 
     @Override
     public String getIconFileName() {
@@ -27,11 +27,11 @@ public class ScriptArgumentAction implements PersistentAction {
     }
 
     @CheckForNull
-    public String getParam() {
-        return this.param;
+    public String getScript() {
+        return this.script;
     }
 
-    public ScriptArgumentAction(String param) {
-        this.param = param;
+    public ScriptArgumentAction(String script) {
+        this.script = script;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -60,6 +60,12 @@ public class ShellStepTest extends Assert {
                 if (sa.getDescriptor().getFunctionName().matches("sh|bat")) {
                     assertSame(BallColor.RED, sa.getIconColor());
                     found = true;
+                    Assert.assertNotNull(sa.getAction(ScriptArgumentAction.class));
+                    if (sa.getDescriptor().getFunctionName().matches("sh")) {
+                        Assert.assertEquals("false", sa.getAction(ScriptArgumentAction.class).getParam());
+                    } else if (sa.getDescriptor().getFunctionName().matches("bat")) {
+                        Assert.assertEquals("whatever", sa.getAction(ScriptArgumentAction.class).getParam());
+                    }
                 }
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -62,9 +62,9 @@ public class ShellStepTest extends Assert {
                     found = true;
                     Assert.assertNotNull(sa.getAction(ScriptArgumentAction.class));
                     if (sa.getDescriptor().getFunctionName().matches("sh")) {
-                        Assert.assertEquals("false", sa.getAction(ScriptArgumentAction.class).getParam());
+                        Assert.assertEquals("false", sa.getAction(ScriptArgumentAction.class).getScript());
                     } else if (sa.getDescriptor().getFunctionName().matches("bat")) {
-                        Assert.assertEquals("whatever", sa.getAction(ScriptArgumentAction.class).getParam());
+                        Assert.assertEquals("whatever", sa.getAction(ScriptArgumentAction.class).getScript());
                     }
                 }
             }


### PR DESCRIPTION
Implements [JENKINS-37324](https://issues.jenkins-ci.org/browse/JENKINS-37324) for shell & batch step, more or less. 

This gives us the script argument that we really need to implement smarter display of batch steps.  Note that I'm not modifying the *displayName* or functionName for the step, because IIRC there is existing logic dependent on that -- but consumers of the flow graph can do the following to get what is needed:

```java
ScriptArgumentAction action = flowNode.getAction(ScriptArgumentAction.class);
String batchOrShellScript = action.getScript();
```

Ta-da!   CC @vivek  and @michaelneale 

I'm not marking it ready to review *yet* because need to look at it with fresh eyes tomorrow and see if there's a smarter way to implement this.

**TODO:**

- [ ] Rejigger this as [described by Jesse](https://issues.jenkins-ci.org/browse/JENKINS-31582) using a direct serialization of the Step in the Actions for the FlowNode (initial version, avoids some compatibility issues there).   This way we can get at far more info from the execution. 

Catch: this serializes far more data.  It might reduce performance if done without a rewrite of flow node storage. 