### PR TITLE
Robustness improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.2</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
- [X] [JENKINS-40613](https://issues.jenkins-ci.org/browse/JENKINS-40613): make sure `FilePath.isDirectory` calls are subject to timeout
- [X] [JENKINS-37730](https://issues.jenkins-ci.org/browse/JENKINS-37730): include more diagnostics in `getStatus`
- [X] [JENKINS-38769](https://issues.jenkins-ci.org/browse/JENKINS-38769): make sure `stop` does something
- [X] [JENKINS-37486](https://issues.jenkins-ci.org/browse/JENKINS-37486): reported `NullPointerException` perhaps due to Guice problems

@reviewbybees