### PR TITLE
[JENKINS-41339] durable-task 1.13 broke an EnvironmentVariablesNodeProperty use case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.12</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -99,7 +99,7 @@ public abstract class DurableTaskStep extends Step {
         this.returnStatus = returnStatus;
     }
 
-    @Override public final StepExecution start(StepContext context) throws Exception {
+    @Override public StepExecution start(StepContext context) throws Exception {
         return new Execution(context, this);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStep.java
@@ -24,9 +24,13 @@
 
 package org.jenkinsci.plugins.workflow.steps.durable_task;
 
+import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.TaskListener;
 import org.jenkinsci.plugins.durabletask.BourneShellScript;
 import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -48,6 +52,14 @@ public final class ShellStep extends DurableTaskStep {
 
     @Override protected DurableTask task() {
         return new BourneShellScript(script);
+    }
+
+    @Override public StepExecution start(StepContext context) throws Exception {
+        String path = context.get(EnvVars.class).get("PATH");
+        if (path != null && path.contains("$PATH")) {
+            context.get(TaskListener.class).getLogger().println("Warning: JENKINS-41339 probably bogus PATH=" + path + "; perhaps you meant to use ‘PATH+EXTRA=/something/bin’?");
+        }
+        return super.start(context);
     }
 
     @Extension public static final class DescriptorImpl extends DurableTaskStepDescriptor {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -41,7 +41,6 @@ import java.util.logging.Level;
 import static java.util.logging.Level.*;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import jenkins.model.Jenkins.MasterComputer;
@@ -520,7 +519,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         label = computer.getName();
 
                         EnvVars env = computer.getEnvironment();
-                        env.overrideAll(computer.buildEnvironment(listener));
+                        env.overrideExpandingAll(computer.buildEnvironment(listener));
                         env.put(COOKIE_VAR, cookie);
                         // Cf. CoreEnvironmentContributor:
                         if (exec.getOwner() instanceof MasterComputer) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -174,6 +174,13 @@ public class ShellStepTest extends Assert {
         }
     }
 
+    @Issue("JENKINS-40734")
+    @Test public void envWithShellChar() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {withEnv(['MONEY=big$$money']) {sh 'echo \"MONEY=$MONEY\"'}}", true));
+        j.assertLogContains("MONEY=big$$money", j.buildAndAssertSuccess(p));
+    }
+
     @Issue("JENKINS-26133")
     @Test public void configRoundTrip() throws Exception {
         ShellStep s = new ShellStep("echo hello");


### PR DESCRIPTION
[JENKINS-41339](https://issues.jenkins-ci.org/browse/JENKINS-41339)

Buggy `sh` behavior corrected in `durable-task` 1.13 exposed a bug in the `node` step.

@reviewbybees