### PR TITLE
[JENKINS-34021] If the step is badly broken, just try to cancel the timer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -216,6 +216,8 @@ public abstract class DurableTaskStep extends Step {
             } catch (Exception x) {
                 LOGGER.log(Level.WARNING, "JENKINS-34021: could not get TaskListener in " + context, x);
                 l = new LogTaskListener(LOGGER, Level.FINE);
+                recurrencePeriod = 0;
+                getContext().onFailure(x);
             }
             return l.getLogger();
         }
@@ -247,6 +249,7 @@ public abstract class DurableTaskStep extends Step {
                 }, 10, TimeUnit.SECONDS);
             } else {
                 logger().println("Could not connect to " + node + " to send interrupt signal to process");
+                recurrencePeriod = 0;
                 getContext().onFailure(cause);
             }
         }


### PR DESCRIPTION
From an installation running with the latest [JENKINS-34021](https://issues.jenkins-ci.org/browse/JENKINS-34021) fixes, get repeated warnings in the log:

```
WARNING	o.j.p.w.s.d.DurableTaskStep$Execution#logger: JENKINS-34021: could not get TaskListener in CpsStepContext[…:sh]:Owner[… #…]java.io.IOException: cannot find current thread
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.doGet(CpsStepContext.java:295)
	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:61)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.logger(DurableTaskStep.java:208)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.access$700(DurableTaskStep.java:138)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$3.call(DurableTaskStep.java:307)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$3.call(DurableTaskStep.java:305)
	at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$4.call(DurableTaskStep.java:359)
	at …
```

There seems to be just one such warning per build, so I am guessing all these builds died, but just to be sure, when we get into this anomalous state it seems appropriate to

- [X] make sure the timer is cancelled
- [X] make sure the step is marked as a failure

@reviewbybees