### PR TITLE
[JENKINS-41446] fix $WORKSPACE in ws step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -2,6 +2,10 @@ package org.jenkinsci.plugins.workflow.support.steps;
 
 import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Computer;
 import hudson.model.Job;
@@ -14,6 +18,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.support.actions.WorkspaceActionImpl;
@@ -60,10 +65,25 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
         flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
         listener.getLogger().println("Running in " + workspace);
         body = getContext().newBodyInvoker()
-                .withContext(workspace)
+                .withContexts(
+                    EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class),
+                        new ExpanderImpl("WORKSPACE", workspace.getRemote())),
+                    workspace)
                 .withCallback(new Callback(lease))
                 .start();
         return false;
+    }
+
+    private static final class ExpanderImpl extends EnvironmentExpander {
+        private static final long serialVersionUID = 1;
+        private final Map<String,String> override;
+        private ExpanderImpl(String var, String value) {
+            this.override = new HashMap<>();
+            this.override.put(var, value);
+        }
+        @Override public void expand(EnvVars env) throws IOException, InterruptedException {
+            env.overrideAll(override);
+        }
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -76,13 +76,12 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
 
     private static final class ExpanderImpl extends EnvironmentExpander {
         private static final long serialVersionUID = 1;
-        private final Map<String,String> override;
+        private final String path;
         private ExpanderImpl(String path) {
-            this.override = new HashMap<>();
-            this.override.put("WORKSPACE", path);
+            this.path = path;
         }
         @Override public void expand(EnvVars env) throws IOException, InterruptedException {
-            env.overrideAll(override);
+            env.override("WORKSPACE", path);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -67,7 +67,7 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
         body = getContext().newBodyInvoker()
                 .withContexts(
                     EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class),
-                        new ExpanderImpl("WORKSPACE", workspace.getRemote())),
+                        new ExpanderImpl(workspace.getRemote())),
                     workspace)
                 .withCallback(new Callback(lease))
                 .start();
@@ -77,9 +77,9 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
     private static final class ExpanderImpl extends EnvironmentExpander {
         private static final long serialVersionUID = 1;
         private final Map<String,String> override;
-        private ExpanderImpl(String var, String value) {
+        private ExpanderImpl(String path) {
             this.override = new HashMap<>();
-            this.override.put(var, value);
+            this.override.put("WORKSPACE", path);
         }
         @Override public void expand(EnvVars env) throws IOException, InterruptedException {
             env.overrideAll(override);


### PR DESCRIPTION
[JENKINS-41446](https://issues.jenkins-ci.org/browse/JENKINS-41446)

I took the EnvStep as example to use the EnvironmentExpander.
As we have only one variable to set, I made ExpanderImpl a bit simpler.

Created unitary tests, including test of NODE_NAME since my first attempt resulted in the variable set to null in the ws step.