### PR TITLE
[JENKINS-37719] Better recovery from hangs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
+            <version>2.13</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>2.21</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.12</version>
+            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.12</version>
+            <version>2.13-20170205.153141-1</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/29 -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -281,6 +281,7 @@ public abstract class DurableTaskStep extends Step {
             }
         }
 
+        @SuppressFBWarnings(value="REC_CATCH_EXCEPTION", justification="silly rule")
         private void check() {
             if (recurrencePeriod == 0) { // from stop
                 return;


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-cps-plugin/pull/102 ensures an eventual timeout of a build facing a `dockerd` outage ([JENKINS-37719](https://issues.jenkins-ci.org/browse/JENKINS-37719)), even without patching `docker-workflow` itself. This patch also improves upon behavior introduced in #23.

Downstream of https://github.com/jenkinsci/workflow-support-plugin/pull/29.

@reviewbybees