### PR TITLE
[JENKINS-34021] Do not overreact if a shell step is abruptly stopped

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -205,10 +205,9 @@ public abstract class DurableTaskStep extends Step {
                     l = new LogTaskListener(LOGGER, Level.FINE);
                 }
             } catch (Exception x) {
-                LOGGER.log(Level.WARNING, "JENKINS-34021: could not get TaskListener in " + context, x);
+                LOGGER.log(Level.FINE, "JENKINS-34021: could not get TaskListener in " + context, x);
                 l = new LogTaskListener(LOGGER, Level.FINE);
                 recurrencePeriod = 0;
-                getContext().onFailure(x);
             }
             return l.getLogger();
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -13,8 +13,11 @@ import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.Shell;
 import java.io.File;
 import java.io.Serializable;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import static org.hamcrest.Matchers.containsString;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsStepContext;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -34,6 +37,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -43,6 +47,8 @@ public class ShellStepTest extends Assert {
     public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Rule public LoggerRule logging = new LoggerRule();
 
     /**
      * Failure in the shell script should mark the step as red
@@ -220,6 +226,21 @@ public class ShellStepTest extends Assert {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {echo \"truth is ${sh script: 'true', returnStatus: true} but falsity is ${sh script: 'false', returnStatus: true}\"}"));
         j.assertLogContains("truth is 0 but falsity is 1", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
+    @Issue("JENKINS-34021")
+    @Test public void deadStep() throws Exception {
+        logging.record(DurableTaskStep.class, Level.INFO).record(CpsStepContext.class, Level.INFO).capture(100);
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep infinity') : bat('ping 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
+        b.doTerm();
+        j.waitForCompletion(b);
+        j.assertBuildStatus(Result.ABORTED, b);
+        for (LogRecord record : logging.getRecords()) {
+            assertNull(record.getThrown());
+        }
     }
 
     /**


### PR DESCRIPTION
[JENKINS-34021](https://issues.jenkins-ci.org/browse/JENKINS-34021)

Amends #28 to not print misleading exceptions if a shell step has been forcibly stopped.

@reviewbybees