### PR TITLE
More logging for ExecutorPickle

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -221,6 +221,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         private static final Map<String,RunningTask> runningTasks = new HashMap<String,RunningTask>();
 
         private final StepContext context;
+        /** Initially set to {@link ExecutorStep#getLabel}, if any; later switched to actual self-label when block runs. */
         private String label;
         /** Shortcut for {@link #run}. */
         private String runId;
@@ -436,7 +437,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public String toString() {
-            return "ExecutorStepExecution.PlaceholderTask{runId=" + runId + ",context=" + context + ",cookie=" + cookie +  '}';
+            return "ExecutorStepExecution.PlaceholderTask{runId=" + runId + ",label=" + label + ",context=" + context + ",cookie=" + cookie +  '}';
         }
 
         private static void finish(@CheckForNull final String cookie) {


### PR DESCRIPTION
There was a reported case in which it seems that one `ExecutorPickle` (from a `parallel` branch running inside `node`) wound up scheduling the same task twice. One copy was accepted, but the other waited in the queue waiting for the one executor slot on the node, so the whole build hanged during resumption. Adding some logging which _might_ have helped with diagnosis, had this logger been enabled at `FINE`.

@reviewbybees