### PR TITLE
Exposing NODE_HOME variable in pipeline

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -539,7 +539,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         }
                         env.put("EXECUTOR_NUMBER", String.valueOf(exec.getNumber()));
                         env.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
-                        env.put("NODE_HOME", node.getRootPath().getRemote());
+                        env.put("NODE_HOME", node.getRootPath() != null ? node.getRootPath().getRemote() : "");
 
                         synchronized (runningTasks) {
                             runningTasks.put(cookie, new RunningTask());

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -539,6 +539,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         }
                         env.put("EXECUTOR_NUMBER", String.valueOf(exec.getNumber()));
                         env.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
+                        env.put("NODE_HOME", node.getRootPath().getRemote());
 
                         synchronized (runningTasks) {
                             runningTasks.put(cookie, new RunningTask());

--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow;
 
+import hudson.EnvVars;
 import hudson.slaves.DumbSlave;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -75,9 +76,10 @@ public class EnvWorkflowTest {
     }
 
     /**
-     * Verifies if NODE_HOME environment variable is available on a slave node and on master.
+     * Verifies if NODE_HOME environment variable is available on an agent and on the master.
      *
-     * @throws Exception
+     * @throws Exception An Exception may occur from creating an Agent @see {@link org.jvnet.hudson.test.JenkinsRule#createSlave(String, String, EnvVars)}}
+     * or from creating a project @see {@link jenkins.model.Jenkins#createProject(Class, String)}
      */
     @Test public void isNodeHomeAvailable() throws Exception {
         DumbSlave remote = r.createSlave("node-test", null, null);

--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -74,6 +74,30 @@ public class EnvWorkflowTest {
         r.assertLogContains("My name on a slave is node-test using labels fast node-test unix", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
+    /**
+     * Verifies if NODE_HOME environment variable is available on a slave node and on master.
+     *
+     * @throws Exception
+     */
+    @Test public void isNodeHomeAvailable() throws Exception {
+        DumbSlave remote = r.createSlave("node-test", null, null);
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('master') {\n" +
+                        "  echo \"My home on master is ${env.NODE_HOME}\"\n" +
+                        "}\n"
+        ));
+        // Need to use JENKINS_HOME here for verification.
+        r.assertLogContains("My home on master is " + r.getInstance().getRootDir().getPath(), r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('node-test') {\n" +
+                        "  echo \"My home on a slave is ${env.NODE_HOME}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My home on a slave is " + remote.getRemoteFS(), r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+}
 
     /**
      * Verifies if EXECUTOR_NUMBER environment variable is available on a slave node and on master.


### PR DESCRIPTION
Creating/Exposing a variable `NODE_HOME` during use in a pipeline.
This variable is similar to `JENKINS_HOME` but for Jenkins' Agent Nodes.

**Reason/Need for this:**
I have a Jenkins environment that builds same type of projects (Maven, NPM, Composer, etc) using Docker for the build tools. These build tools have their own caching mechanism for their dependencies.
Since using Docker, these containers are short lived and do not persist the cache dependencies. Resulting in the dependencies re-downloading for every build. This is slow and takes up a lot of network bandwidth.

A way to persist the cache dependencies is to mount a shared volume (docker volume mount from host to container) for the dependency cache. To be able to do this we need a writable directory (as the Jenkins user) outside of the workspace (as it may be wiped before each build) so it can be reused during builds.

**Temp/Manual Workaround:**
Login to each Jenkins server (master and agents) and manually create these cache directories in the Jenkins home directory.
Make sure all Jenkins agents have the same user/home directory.

**Workaround Issues:**
Depending on your organization you may not always have authority to create the same setups for Jenkins/home directory (ie Windows vs Unix or system admins different setup procedures).
Extra steps to provision your Jenkins Agents.

**Other Possible Benefits:**
Organizations/users may have Jenkins specific scripts relative to the Jenkins Users home for execution. This provides a better way to get the path instead of doing `../../script.sh` from the workspace.