### PR TITLE
Fix JENKINS-28182

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -212,7 +212,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         @Nullable Launcher launcher;
     }
 
-    private static final String COOKIE_VAR = "JENKINS_SERVER_COOKIE";
+    private static final String COOKIE_VAR = "JENKINS_NODE_COOKIE";
 
     @ExportedBean
     public static final class PlaceholderTask implements ContinuedTask, Serializable, AccessControlled {


### PR DESCRIPTION
The durable task plugin should use a different environment variable to track child processes.  Originally it overrode the JENKINS_SERVER_COOKIE variable, to ensure that the process killing done at the end of a node block would not kill tasks running in other node blocks on the same machine.  However, the killer would attempt to kill processes based on the original value of JENKINS_SERVER_COOKIE.  This means that no processes started in a node block would be killed.  With this fix, JENKINS_NODE_COOKIE is now used.  Added test to ensure that killing functionality works properly.