### PR TITLE
Apply a Timeout to getStatus internally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.3'])
+buildPlugin(jenkinsVersions: [null, '2.60.1'])

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -250,7 +250,7 @@ public abstract class DurableTaskStep extends Step {
 
         @Override public String getStatus() {
             StringBuilder b = new StringBuilder();
-            try {
+            try (Timeout timeout = Timeout.limit(2, TimeUnit.SECONDS)) { // CpsThreadDump applies a 3s timeout anyway
                 FilePath workspace = getWorkspace();
                 if (workspace != null) {
                     b.append(controller.getDiagnostics(workspace, launcher()));
@@ -258,7 +258,7 @@ public abstract class DurableTaskStep extends Step {
                     b.append("waiting to reconnect to ").append(remote).append(" on ").append(node);
                 }
             } catch (IOException | InterruptedException x) {
-                b.append("failed to look up workspace: ").append(x);
+                b.append("failed to look up workspace ").append(remote).append(" on ").append(node).append(": ").append(x);
             }
             b.append("; recurrence period: ").append(recurrencePeriod).append("ms");
             ScheduledFuture<?> t = task;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -67,8 +67,8 @@ public class ExecutorPickleTest {
             @Override public void evaluate() throws Throwable {
                 SemaphoreStep.success("wait/1", null);
                 WorkflowRun b = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
-                r.j.waitForMessage(hudson.model.Messages.Queue_WaitingForNextAvailableExecutor(), b);
-                r.j.assertLogContains(Messages.ExecutorPickle_waiting_to_resume(Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getFullDisplayName())), b);
+                // first prints on 2.35-: hudson.model.Messages.Queue_WaitingForNextAvailableExecutor(); 2.36+: hudson.model.Messages.Node_LabelMissing("Jenkins", "slave0")
+                r.j.waitForMessage(Messages.ExecutorPickle_waiting_to_resume(Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getFullDisplayName())), b);
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 Queue.getInstance().cancel(items[0]);


### PR DESCRIPTION
The virtual thread dump applies a timeout to every step “stack frame” anyway, but if `Controller.getDiagnostics` hangs due to a broken Remoting channel, it will just print something like

```
    at DSL.bat(java.util.concurrent.TimeoutException)
```

which is not as informative as it could be.

@reviewbybees