### PR TITLE
Amending JENKINS-34542 fix for JENKINS-45553

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -545,6 +545,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 Timer.get().submit(new Runnable() { // JENKINS-31614
                     @Override public void run() {
                         execution.completed(null);
+                    }
+                });
+                Computer.threadPoolForRemoting.submit(new Runnable() { // JENKINS-34542, JENKINS-45553
+                    @Override
+                    public void run() {
                         try {
                             runningTask.launcher.kill(Collections.singletonMap(COOKIE_VAR, cookie));
                         } catch (ChannelClosedException x) {


### PR DESCRIPTION
Amending #3 for [JENKINS-45553](https://issues.jenkins-ci.org/browse/JENKINS-45553). Otherwise we tend to suck up all available `Timer` threads, causing various problems such as `copyLogs` starvation (pending JENKINS-38381).

@reviewbybees