### PR TITLE
Fix [JENKINS-36013] by adding a timeout if waiting to resume on unknown node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <workflow-step-api-plugin.version>2.11</workflow-step-api-plugin.version>
     </properties>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -126,7 +126,7 @@ public class ExecutorPickle extends Pickle {
                                 Queue.getInstance().cancel(item);
                                 if (isEphemeral()) {
                                     throw new AbortException(MessageFormat.format("Killed {0} because EphemeralNode {1} is never going to reappear, by definition!",
-                                            new Object[]{item, TIMEOUT_WAITING_FOR_NODE_MILLIS, task.getAssignedLabel().toString()}));
+                                            new Object[]{item, task.getAssignedLabel().toString()}));
                                 } else {
                                     throw new AbortException(MessageFormat.format("Killed {0} after waiting for {1} ms because we assume unknown Node {1} is never going to appear!",
                                             new Object[]{item, TIMEOUT_WAITING_FOR_NODE_MILLIS, placeholder.getAssignedLabel().toString()}));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -275,6 +275,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return new PlaceholderExecutable();
         }
 
+        @CheckForNull
+        public String getCookie() {
+            return cookie;
+        }
+
         @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
         @Override public Label getAssignedLabel() {
             if (label == null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -5,6 +5,7 @@ import hudson.EnvVars;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.LauncherDecorator;
+import hudson.Platform;
 import hudson.model.BallColor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
@@ -237,7 +238,7 @@ public class ShellStepTest {
     @Test public void deadStep() throws Exception {
         logging.record(DurableTaskStep.class, Level.INFO).record(CpsStepContext.class, Level.INFO).capture(100);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep infinity') : bat('ping 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
+        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep 1000000') : bat('ping 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
         b.doTerm();

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -238,7 +238,7 @@ public class ShellStepTest {
     @Test public void deadStep() throws Exception {
         logging.record(DurableTaskStep.class, Level.INFO).record(CpsStepContext.class, Level.INFO).capture(100);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep 1000000') : bat('ping 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
+        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep 1000000') : bat('ping -t 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
         b.doTerm();

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -194,13 +194,12 @@ public class ExecutorPickleTest {
         r.addStep(new Statement() {
             // Start up a build and then reboot and take the node offline
             @Override public void evaluate() throws Throwable {
+                Thread.sleep(1000L);
+                assertNull(r.j.jenkins.getNode("ghostly")); // Disconnected and deleted, it's ephemeral, duh
                 WorkflowRun run = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();
                 Assert.assertTrue("Build should not die immediately if it can't obtain EphemeralNode ExecutorPickle", run.isBuilding());
-
-                assertNull(r.j.jenkins.getNode("ghostly")); // Disconnected and deleted, it's ephemeral, duh
-
                 try {
-                    r.j.wait(10000L);
+                    Thread.sleep(10000L);
                     Assert.assertFalse(run.isBuilding());
                     r.j.assertBuildStatus(Result.FAILURE, run);
                 } catch (InterruptedIOException ioe) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -188,7 +188,7 @@ public class ExecutorPickleTest {
                 spectre.addIfMissingAndWaitForOnline(r.j);
                 r.j.jenkins.save();
                 SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
-                ExecutorPickle.TIMEOUT_WAITING_FOR_EPHMERAL_NODE = 4000L; // fail faster
+                ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS = 4000L; // fail faster
             }
         });
 
@@ -203,7 +203,7 @@ public class ExecutorPickleTest {
                 Assert.assertEquals("Queue should still have single build Item waiting to resume but didn't", 1, Queue.getInstance().getItems().length);
 
                 try {
-                    Thread.sleep(ExecutorPickle.TIMEOUT_WAITING_FOR_EPHMERAL_NODE + 1000L);
+                    Thread.sleep(ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS + 1000L);
                     Assert.assertEquals("Should have given up and killed the Task representing the resuming build", 0, Queue.getInstance().getItems().length );
                     Assert.assertFalse(run.isBuilding());
                     r.j.assertBuildStatus(Result.FAILURE, run);


### PR DESCRIPTION
See [JENKINS-36013](https://issues.jenkins-ci.org/browse/JENKINS-36013). 

For this I've not limited this to EphemeralNodes because (for example) Docker slaves may not implement EphemeralNode but may exhibit the same "once it's gone it ain't coming back" behavior.  

However I did add a boolean to track if the slave is ephemeral so that goes into the logs. 