### PR TITLE
Make ExecutorPickle wait on EphemeralNodes when trying to resume, restoring original behavior of fix to JENKINS-36013

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -122,15 +122,10 @@ public class ExecutorPickle extends Pickle {
                         // Thus we're guaranteeing the execution began and the Node is now unknown.
                         // Theoretically it's safe to simply fail earlier when rehydrating any EphemeralNode... but we're being extra safe.
                         if (placeholder.getCookie() != null && Jenkins.getActiveInstance().getNode(placeholder.getAssignedLabel().getName()) == null ) {
-                            if (isEphemeral() || System.nanoTime() > endTimeNanos) {
+                            if (System.nanoTime() > endTimeNanos) {
                                 Queue.getInstance().cancel(item);
-                                if (isEphemeral()) {
-                                    throw new AbortException(MessageFormat.format("Killed {0} because EphemeralNode {1} is never going to reappear, by definition!",
-                                            new Object[]{item, task.getAssignedLabel().toString()}));
-                                } else {
                                     throw new AbortException(MessageFormat.format("Killed {0} after waiting for {1} ms because we assume unknown Node {1} is never going to appear!",
                                             new Object[]{item, TIMEOUT_WAITING_FOR_NODE_MILLIS, placeholder.getAssignedLabel().toString()}));
-                                }
                             }
                         }
                     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -201,39 +201,7 @@ public class ExecutorPickleTest {
 
     /**
      * Test that {@link ExecutorPickle} won't spin forever trying to rehydrate if it was using an
-     *  EphemeralNode that disappeared and will never reappear... for EphemeralNodes it should just die.
-     */
-    @Issue("JENKINS-36013")
-    @Test public void ephemeralNodeDisappearance() throws Exception {
-        r.addStep(new Statement() {
-            // Start up a build that needs executor and then reboot and take the node offline
-            @Override public void evaluate() throws Throwable {
-                // Starting job first ensures we don't immediately fail if Node comes from a Cloud
-                //  and takes a min to provision
-                WorkflowJob p = r.j.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("node('ghost') {semaphore 'wait'}", true));
-
-                EphemeralDumbAgent spectre = new EphemeralDumbAgent(r.j, "ghost");
-                spectre.addIfMissingAndWaitForOnline(r.j);
-                r.j.jenkins.save();
-                SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
-            }
-        });
-
-        r.addStep(new Statement() {
-            // Start up a build and then reboot and take the node offline
-            @Override public void evaluate() throws Throwable {
-                assertNull(r.j.jenkins.getNode("ghostly")); // Make sure test impl is correctly deleted
-                WorkflowRun run = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();
-                Thread.sleep(200L);
-                r.j.waitForMessage("because EphemeralNode ghostly is never going to reappear, by definition!", run);
-            }
-        });
-    }
-
-    /**
-     * Test that {@link ExecutorPickle} won't spin forever trying to rehydrate if it was using an
-     *  non-ephemeral node that disappeared and will never reappear... but still waits a little bit to find out.
+     *  node that disappeared and will never reappear... but still waits a little bit to find out.
      *
      *  I.E. cases where the {@link RetentionStrategy} is {@link RetentionStrategy#NOOP}.
      */


### PR DESCRIPTION
Per comment here, immediately failing builds with an ExecutorPickle that depends on an EphemeralNode is not safe to do, due to the Swarm Plugin.   Documented [in the JIRA comments](https://issues.jenkins-ci.org/browse/JENKINS-36013?focusedCommentId=311834&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-311834).

So, I am restoring my original behavior (apply a timeout in all cases).  Can't remove the new field, though.

@reviewbybees CC @jglick 