### PR TITLE
PlaceHolderTask should be submitted with a reference to the upstream Run.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -9,7 +9,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.console.ModelHyperlinkNote;
-import hudson.model.Actionable;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Computer;
@@ -244,7 +243,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
     @ExportedBean
     public static final class PlaceholderTask implements ContinuedTask, Serializable, AccessControlled {
-        Actionable a;
 
         /** keys are {@link #cookie}s */
         private static final Map<String,RunningTask> runningTasks = new HashMap<String,RunningTask>();


### PR DESCRIPTION
I have not created JIRA tickets for it yet.

It fixes issues like JENKINS-34377 (restriction of PlaceHolder tasks by users in Job Restrictions) in a more generic way (see the current plugin-side fix in https://github.com/jenkinsci/job-restrictions-plugin/pull/20). With the such patch this plugin will start working as well as other plugins depending on `UpstreamCause#getUpstreamCauses()` resolution (e.g. https://github.com/search?p=1&q=org%3Ajenkinsci+getUpstreamCauses%28%29&type=Code)

@reviewbybees @msqb @jglick @abayer @svanoort 


