### PR TITLE
[JEP-206] Gather command output in a local encoding

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-4</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.121.1'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.73.1'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.14</version>
+        <version>3.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -67,7 +67,7 @@
         <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>2.19-rc287.918f5958551d</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
+        <workflow-support-plugin.version>2.20-rc569.8b4964ac1954</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
     </properties>
     <dependencies>
         <dependency>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.23-rc125.7208013b9494</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/61 -->
+            <version>1.24-rc319.e1ef73b3ab09</version> <!-- TODO pending release -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.22-rc329.5cb884ef714a</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/89 -->
+            <version>2.24-rc765.2c5d9ffed127</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/89 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>2.20-rc569.8b4964ac1954</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
+        <workflow-support-plugin.version>2.20</workflow-support-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.24-rc319.e1ef73b3ab09</version> <!-- TODO pending release -->
+            <version>1.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>3.4</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -62,9 +62,10 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
+        <workflow-support-plugin.version>2.19-20180209.204154-1</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
     </properties>
     <dependencies>
         <dependency>
@@ -75,17 +76,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.18-20180125.194359-1</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/57 -->
+            <version>1.18-20180212.221815-3</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/61 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.16</version>
+            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -96,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>2.18-20180209.215341-1</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/89 -->
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,7 +122,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13</version>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -134,12 +135,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.27</version>
+            <version>1.39</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.2.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.19-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/61 -->
+            <version>1.19-20180219.185547-1</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/61 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -58,6 +58,8 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
 import org.jenkinsci.plugins.workflow.support.concurrent.WithThreadName;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -104,6 +106,7 @@ public abstract class DurableTaskStep extends Step {
 
     public abstract static class DurableTaskStepDescriptor extends StepDescriptor {
 
+        @Restricted(DoNotUse.class)
         public FormValidation doCheckEncoding(@QueryParameter boolean returnStdout, @QueryParameter String encoding) {
             if (encoding.isEmpty()) {
                 return FormValidation.ok();

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -30,6 +30,7 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.FormValidation;
@@ -37,6 +38,7 @@ import hudson.util.LogTaskListener;
 import hudson.util.NamingThreadFactory;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -67,7 +69,7 @@ public abstract class DurableTaskStep extends Step {
     private static final Logger LOGGER = Logger.getLogger(DurableTaskStep.class.getName());
 
     private boolean returnStdout;
-    private String encoding = DurableTaskStepDescriptor.defaultEncoding;
+    private String encoding;
     private boolean returnStatus;
 
     protected abstract DurableTask task();
@@ -85,7 +87,7 @@ public abstract class DurableTaskStep extends Step {
     }
 
     @DataBoundSetter public void setEncoding(String encoding) {
-        this.encoding = encoding;
+        this.encoding = Util.fixEmpty(encoding);
     }
 
     public boolean isReturnStatus() {
@@ -102,16 +104,14 @@ public abstract class DurableTaskStep extends Step {
 
     public abstract static class DurableTaskStepDescriptor extends StepDescriptor {
 
-        public static final String defaultEncoding = "UTF-8";
-
         public FormValidation doCheckEncoding(@QueryParameter boolean returnStdout, @QueryParameter String encoding) {
+            if (encoding.isEmpty()) {
+                return FormValidation.ok();
+            }
             try {
                 Charset.forName(encoding);
             } catch (Exception x) {
                 return FormValidation.error(x, "Unrecognized encoding");
-            }
-            if (!returnStdout && !encoding.equals(DurableTaskStepDescriptor.defaultEncoding)) {
-                return FormValidation.warning("encoding is ignored unless returnStdout is checked.");
             }
             return FormValidation.ok();
         }
@@ -154,7 +154,6 @@ public abstract class DurableTaskStep extends Step {
         private String node;
         private String remote;
         private boolean returnStdout; // serialized default is false
-        private String encoding; // serialized default is irrelevant
         private boolean returnStatus; // serialized default is false
 
         Execution(StepContext context, DurableTaskStep step) {
@@ -164,7 +163,6 @@ public abstract class DurableTaskStep extends Step {
 
         @Override public boolean start() throws Exception {
             returnStdout = step.returnStdout;
-            encoding = step.encoding;
             returnStatus = step.returnStatus;
             StepContext context = getContext();
             ws = context.get(FilePath.class);
@@ -172,6 +170,11 @@ public abstract class DurableTaskStep extends Step {
             DurableTask durableTask = step.task();
             if (returnStdout) {
                 durableTask.captureOutput();
+            }
+            if (step.encoding != null) {
+                durableTask.charset(Charset.forName(step.encoding));
+            } else {
+                durableTask.defaultCharset();
             }
             controller = durableTask.launch(context.get(EnvVars.class), ws, context.get(Launcher.class), context.get(TaskListener.class));
             this.remote = ws.getRemote();
@@ -327,7 +330,7 @@ public abstract class DurableTaskStep extends Step {
                                 LOGGER.log(Level.FINE, "last-minute output in {0} on {1}", new Object[] {remote, node});
                             }
                             if (returnStatus || exitCode == 0) {
-                                getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(controller.getOutput(workspace, launcher()), encoding) : null);
+                                getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(controller.getOutput(workspace, launcher()), StandardCharsets.UTF_8) : null);
                             } else {
                                 if (returnStdout) {
                                     listener.getLogger().write(controller.getOutput(workspace, launcher())); // diagnostic

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/config.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
             <f:checkbox/>
         </f:entry>
         <f:entry field="encoding" title="${%Encoding of standard output}">
-            <f:textbox default="${descriptor.defaultEncoding}"/>
+            <f:textbox/>
         </f:entry>
         <f:entry field="returnStatus" title="${%Return exit status}">
             <f:checkbox/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
@@ -1,3 +1,6 @@
 <div>
-    Encoding of standard output, if it is being captured.
+    Encoding of process output.
+    In the case of <code>returnStdout</code>, applies to the return value of this step;
+    otherwise, or always for standard error, controls how text is copied to the build log.
+    If unspecified, uses the system default encoding of the node on which the step is run.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
@@ -2,7 +2,11 @@
     Encoding of process output.
     In the case of <code>returnStdout</code>, applies to the return value of this step;
     otherwise, or always for standard error, controls how text is copied to the build log.
-    If unspecified, uses the system default encoding of the node on which the step is run,
-    but if there is any expectation that process output might include non-ASCII characters,
+    If unspecified, uses the system default encoding of the node on which the step is run.
+    If there is any expectation that process output might include non-ASCII characters,
     it is best to specify the encoding explicitly.
+    For example, if you have specific knowledge that a given process is going to be producing UTF-8
+    yet will be running on a node with a different system encoding
+    (typically Windows, since every Linux distribution has defaulted to UTF-8 for a long time),
+    you can ensure correct output by specifying: <code>encoding: 'UTF-8'</code>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-encoding.html
@@ -2,5 +2,7 @@
     Encoding of process output.
     In the case of <code>returnStdout</code>, applies to the return value of this step;
     otherwise, or always for standard error, controls how text is copied to the build log.
-    If unspecified, uses the system default encoding of the node on which the step is run.
+    If unspecified, uses the system default encoding of the node on which the step is run,
+    but if there is any expectation that process output might include non-ASCII characters,
+    it is best to specify the encoding explicitly.
 </div>


### PR DESCRIPTION
[JEP-206](https://github.com/jenkinsci/jep/blob/master/jep/206/README.adoc)

Extracted from #21. Downstream of https://github.com/jenkinsci/durable-task-plugin/pull/61. Also downstream of https://github.com/jenkinsci/workflow-job-plugin/pull/89 for testing, but really as a user you want to update `workflow-job` as well, unless your master happens to be running in UTF-8.