### PR TITLE
Fixing an error in ExecutorStepTest.authentication

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.workflow.support.steps;
 
-import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -27,12 +26,14 @@ import hudson.model.queue.SubTask;
 import hudson.remoting.ChannelClosedException;
 import hudson.remoting.RequestAbortedException;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
 import hudson.slaves.WorkspaceList;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,7 +69,6 @@ import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.steps.durable_task.Messages;
 import org.jenkinsci.plugins.workflow.support.actions.WorkspaceActionImpl;
 import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
@@ -111,7 +111,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     try {
                         logger = getContext().get(TaskListener.class).getLogger();
                     } catch (Exception x) { // IOException, InterruptedException
-                        LOGGER.log(WARNING, null, x);
+                        LOGGER.log(FINE, "could not print message to build about " + item + "; perhaps it is already completed", x);
                         return;
                     }
                     logger.println("Still waiting to schedule task");
@@ -127,11 +127,26 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
     @Override
     public void stop(Throwable cause) throws Exception {
-        for (Queue.Item item : Queue.getInstance().getItems()) {
+        Queue.Item[] items;
+        try (ACLContext as = ACL.as(ACL.SYSTEM)) {
+            items = Queue.getInstance().getItems();
+        }
+        LOGGER.log(FINE, "stopping one of {0}", Arrays.asList(items));
+        StepContext context = getContext();
+        for (Queue.Item item : items) {
             // if we are still in the queue waiting to be scheduled, just retract that
-            if (item.task instanceof PlaceholderTask && ((PlaceholderTask) item.task).context.equals(getContext())) {
-                Queue.getInstance().cancel(item);
-                break;
+            if (item.task instanceof PlaceholderTask) {
+                PlaceholderTask task = (PlaceholderTask) item.task;
+                if (task.context.equals(context)) {
+                    task.stopping = true;
+                    Queue.getInstance().cancel(item);
+                    LOGGER.log(FINE, "canceling {0}", item);
+                    break;
+                } else {
+                    LOGGER.log(FINE, "no match on {0} with {1} vs. {2}", new Object[] {item, task.context, context});
+                }
+            } else {
+                LOGGER.log(FINE, "no match on {0}", item);
             }
         }
         Jenkins j = Jenkins.getInstance();
@@ -141,9 +156,17 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             COMPUTERS: for (Computer c : j.getComputers()) {
                 for (Executor e : c.getExecutors()) {
                     Queue.Executable exec = e.getCurrentExecutable();
-                    if (exec instanceof PlaceholderTask.PlaceholderExecutable && ((PlaceholderTask.PlaceholderExecutable) exec).getParent().context.equals(getContext())) {
-                        PlaceholderTask.finish(((PlaceholderTask.PlaceholderExecutable) exec).getParent().cookie);
-                        break COMPUTERS;
+                    if (exec instanceof PlaceholderTask.PlaceholderExecutable) {
+                        StepContext actualContext = ((PlaceholderTask.PlaceholderExecutable) exec).getParent().context;
+                        if (actualContext.equals(context)) {
+                            PlaceholderTask.finish(((PlaceholderTask.PlaceholderExecutable) exec).getParent().cookie);
+                            LOGGER.log(FINE, "canceling {0}", exec);
+                            break COMPUTERS;
+                        } else {
+                            LOGGER.log(FINE, "no match on {0} with {1} vs. {2}", new Object[] {exec, actualContext, context});
+                        }
+                    } else {
+                        LOGGER.log(FINE, "no match on {0}", exec);
                     }
                 }
             }
@@ -213,7 +236,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         @Override public void onLeft(Queue.LeftItem li) {
             if (li.isCancelled()) {
                 if (li.task instanceof PlaceholderTask) {
-                    (((PlaceholderTask) li.task).context).onFailure(new AbortException(Messages.ExecutorStepExecution_queue_task_cancelled()));
+                    PlaceholderTask task = (PlaceholderTask) li.task;
+                    if (!task.stopping) {
+                        task.context.onFailure(new AbortException(Messages.ExecutorStepExecution_queue_task_cancelled()));
+                    }
                 }
             }
         }
@@ -252,6 +278,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
         /** {@link Authentication#getName} of user of build, if known. */
         private final @CheckForNull String auth;
+
+        /** Flag to remember that {@link #stop} is being called, so {@link CancelledItemListener} can be suppressed. */
+        private transient boolean stopping;
 
         PlaceholderTask(StepContext context, String label) throws IOException, InterruptedException {
             this.context = context;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -74,7 +74,7 @@ import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.acegisecurity.Authentication;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.util.JavaEnvUtils;
-import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.*;
 import org.jboss.marshalling.ObjectResolver;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
@@ -105,6 +105,7 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 import javax.annotation.Nullable;
+import org.jvnet.hudson.test.LoggerRule;
 
 /** Tests pertaining to {@code node} and {@code sh} steps. */
 public class ExecutorStepTest {
@@ -112,9 +113,7 @@ public class ExecutorStepTest {
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
-    /* Currently too noisy due to unrelated warnings; might clear up if test dependencies updated:
-    @Rule public LoggerRule logging = new LoggerRule().record(ExecutorStepExecution.class, Level.FINE);
-    */
+    @Rule public LoggerRule logging = new LoggerRule();
 
     /**
      * Executes a shell script build on a slave.
@@ -642,7 +641,7 @@ public class ExecutorStepTest {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b = p.getBuildByNumber(1);
-                assertThat(patchedFiles, Matchers.containsInAnyOrder(/* "program.dat", */"3.xml", "3.log", "log"));
+                assertThat(patchedFiles, containsInAnyOrder(/* "program.dat", */"3.xml", "3.log", "log"));
                 /* TODO this seems to randomly not include the expected items:
                 assertThat(patchedFields, Matchers.containsInAnyOrder(
                     // But not FileMonitoringController.controlDir, since this old version is still using location-independent .id.
@@ -737,6 +736,7 @@ public class ExecutorStepTest {
     @Issue("SECURITY-675")
     @Test public void authentication() {
         story.then(r -> {
+            logging.record(ExecutorStepExecution.class, Level.FINE);
             Slave s = r.createSlave("remote", null, null);
             r.waitOnline(s);
             r.jenkins.setNumExecutors(0);
@@ -755,6 +755,7 @@ public class ExecutorStepTest {
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MainAuthenticator());
             p.setDefinition(new CpsFlowDefinition("timeout(time: 5, unit: 'SECONDS') {node {error 'should not be allowed'}}", true));
             r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));
+            assertThat(Queue.getInstance().getItems(), emptyArray());
             // What about when there is a fallback authenticator?
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new FallbackAuthenticator());
             r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0));


### PR DESCRIPTION
A little rabbit hole here. I had jotted down but temporarily set aside a (nonfatal) stack trace printed during a recently added test, `ExecutorStepTest.authentication`:

```
java.io.IOException: cannot find current thread
	at org.jenkinsci.plugins.workflow.cps.CpsStepContext.doGet(CpsStepContext.java:295)
	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:61)
	at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$1.run(ExecutorStepExecution.java:112)
	at …
```

Now first of all, it is a little extreme to print a system warning just because we are unable to get a reference to a build log to print an informational message to it. In the test

```groovy
timeout(time: 5, unit: 'SECONDS') {node {error 'should not be allowed'}}
```

the message is printed 15s after the `node` step starts, by which time the build has already aborted—fine, we do not need to print anything to the log of a completed build!

But then I thought, wait, why is that `Queue.Item` still there? After all, `stop` had already been called by the `timeout` step, and this is supposed to cancel any outstanding queue items associated with the `node` block. Turns out that in this case the `dev` user lacked enough permission to `Item.READ` that job, so `Queue.items` was coming back as an empty array. (A little artificial, since the build is running “as” this user, so normally they would be able to read it too, but whatever.) Really `Queue.getItems` needs to run as `SYSTEM` to make sure all items are checked—we are already looking for a specific item so this is not an information leak. OK, with that fixed, the item is successfully cancelled, but…

…then you get a nasty error from `CpsStepExecution` because it is getting aborted _twice_: once by `super.stop` (from `timeout`); once by `CancelledItemListener`, because now the placeholder task is getting cancelled. And trying to stop the same step twice with different causes is currently treated as a warning (code bug somewhere). Anyway the `AbortException` was delivered first, making the build a `FAILURE`, not `ABORTED`. So fixing the logic so that only a single `onFailure` is delivered, with the user abort.

Got all that? @reviewbybees