### PR TITLE
[JENKINS-54356] Add to node API for pipeline builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,12 +141,5 @@
             <artifactId>structs</artifactId>
             <version>1.7</version>
         </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-            <scope>test</scope>
-            <type>jar</type>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -141,5 +141,12 @@
             <artifactId>structs</artifactId>
             <version>1.7</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -849,24 +849,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
             @Override
             public ACL getACL() {
-                try {
-                    if (!context.isReady()) {
-                        return Jenkins.getActiveInstance().getACL();
-                    }
-                    FlowExecution exec = context.get(FlowExecution.class);
-                    if (exec == null) {
-                        return Jenkins.getActiveInstance().getACL();
-                    }
-                    Queue.Executable executable = exec.getOwner().getExecutable();
-                    if (executable instanceof AccessControlled) {
-                        return ((AccessControlled) executable).getACL();
-                    } else {
-                        return Jenkins.getActiveInstance().getACL();
-                    }
-                } catch (Exception x) {
-                    LOGGER.log(FINE, null, x);
-                    return Jenkins.getActiveInstance().getACL();
-                }
+                return getParent().getACL();
             }
 
             @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -634,7 +634,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
          * Occupies {@link Executor} while workflow uses this slave.
          */
         @ExportedBean
-        public final class PlaceholderExecutable implements ContinuableExecutable {
+        private final class PlaceholderExecutable implements ContinuableExecutable {
 
             @Override public void run() {
                 final TaskListener listener;
@@ -757,7 +757,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             @Exported
             public Integer getNumber() {
                 Run<?, ?> r = getParent().runForDisplay();
-                return r != null ? r.getNumber() : null;
+                return r != null ? r.getNumber() : -1;
             }
 
             @Exported

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -75,6 +75,7 @@ import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 public class ExecutorStepExecution extends AbstractStepExecutionImpl {
@@ -633,7 +634,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
          * Occupies {@link Executor} while workflow uses this slave.
          */
         @ExportedBean
-        private final class PlaceholderExecutable implements ContinuableExecutable {
+        public final class PlaceholderExecutable implements ContinuableExecutable {
 
             @Override public void run() {
                 final TaskListener listener;
@@ -753,6 +754,23 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return PlaceholderTask.this;
             }
 
+            @Exported
+            public int getNumber() {
+                Run<?, ?> r = getParent().runForDisplay();
+                return r != null ? r.getNumber() : -1;
+            }
+
+            @Exported
+            public String getFullDisplayName() {
+                return getParent().getFullDisplayName();
+            }
+
+            @Exported
+            public String getDisplayName() {
+                return getParent().getDisplayName();
+            }
+
+            @Exported
             @Override public long getEstimatedDuration() {
                 return getParent().getEstimatedDuration();
             }
@@ -768,9 +786,18 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return Executor.of(this);
             }
 
-            @Restricted(NoExternalUse.class) // for Jelly
+            @Exported @Restricted(NoExternalUse.class) // for Jelly and toString
             public String getUrl() {
-                return PlaceholderTask.this.getUrl(); // we hope this has a console.jelly
+                Run<?,?> r = runForDisplay();
+                if (r == null) {
+                    return "";
+                }
+                Jenkins j = Jenkins.getInstance();
+                String base = "";
+                if (j != null) {
+                    base = Util.removeTrailingSlash(j.getRootUrl()) + "/";
+                }
+                return base + r.getUrl();
             }
 
             @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -755,9 +755,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
 
             @Exported
-            public int getNumber() {
+            public Integer getNumber() {
                 Run<?, ?> r = getParent().runForDisplay();
-                return r != null ? r.getNumber() : -1;
+                return r != null ? r.getNumber() : null;
             }
 
             @Exported
@@ -775,6 +775,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return getParent().getEstimatedDuration();
             }
 
+            @Exported
+            public Long getTimestamp() {
+                Run<?, ?> r = getParent().runForDisplay();
+                return r != null ? r.getStartTimeInMillis() : null;
+            }
+
             @Override public boolean willContinue() {
                 synchronized (runningTasks) {
                     return runningTasks.containsKey(cookie);
@@ -786,8 +792,13 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return Executor.of(this);
             }
 
-            @Exported @Restricted(NoExternalUse.class) // for Jelly and toString
+            @Restricted(NoExternalUse.class) // for Jelly and toString
             public String getUrl() {
+                return PlaceholderTask.this.getUrl(); // we hope this has a console.jelly
+            }
+
+            @Exported(name="url")
+            public String getAbsoluteUrl() {
                 Run<?,?> r = runForDisplay();
                 if (r == null) {
                     return "";

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -550,7 +550,7 @@ public class ExecutorStepTest {
                 JenkinsRule.WebClient wc = story.j.createWebClient();
                 Page page = wc
                         .goTo("computer/" + s.getNodeName()
-                                + "/api/json?tree=executors[currentExecutable[number,displayName,url,timestamp]]", "application/json");
+                                + "/api/json?tree=executors[currentExecutable[number,displayName,fullDisplayName,url,timestamp]]", "application/json");
 
                 JSONObject propertiesJSON = (JSONObject) (new JsonSlurper()).parseText(page.getWebResponse().getContentAsString());
                 JSONArray executors = propertiesJSON.getJSONArray("executors");
@@ -559,8 +559,11 @@ public class ExecutorStepTest {
 
                 assertEquals(1, currentExecutable.get("number"));
 
-                assertEquals("part of " + p.getName() + " #1",
+                assertEquals("part of " + b.getFullDisplayName(),
                         currentExecutable.get("displayName"));
+
+                assertEquals("part of " + p.getFullDisplayName() + " #1",
+                        currentExecutable.get("fullDisplayName"));
 
                 assertEquals(story.j.getURL().toString() + "job/" + p.getName() + "/1/",
                         currentExecutable.get("url"));


### PR DESCRIPTION
Based off of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/19.

Implements [JENKINS-54356](https://issues.jenkins-ci.org/browse/JENKINS-54356)

The node API currently shows run details for freestyle builds, but not pipeline builds. 