### PR TITLE
Make node() block reuse previously used node if available

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.workflow.support.steps;
 
-import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.EnvVars;
@@ -68,7 +67,6 @@ import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.steps.durable_task.Messages;
 import org.jenkinsci.plugins.workflow.support.actions.WorkspaceActionImpl;
 import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
@@ -310,7 +308,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
-        @Override public Node getLastBuiltOn() {
+        @Override public Node getLastBuiltOn()   {
             if (label == null) {
                 return null;
             }
@@ -437,12 +435,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             // TODO more generic to check whether FlowExecution.owner.executable is a ModelObject
             Run<?,?> r = runForDisplay();
             if (r != null) {
-                String runDisplayName = r.getFullDisplayName();
+				String jobName =  r.getParent().getName();
                 String enclosingLabel = getEnclosingLabel();
                 if (enclosingLabel != null) {
-                    return Messages.ExecutorStepExecution_PlaceholderTask_displayName_label(runDisplayName, enclosingLabel);
+                    return Messages.ExecutorStepExecution_PlaceholderTask_displayName_label(jobName, enclosingLabel);
                 } else {
-                    return Messages.ExecutorStepExecution_PlaceholderTask_displayName(runDisplayName);
+                    return Messages.ExecutorStepExecution_PlaceholderTask_displayName(jobName);
                 }
             } else {
                 return Messages.ExecutorStepExecution_PlaceholderTask_displayName(runId);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -98,7 +98,7 @@ public class ShellStepTest {
                 "echo . >" + tmp + "\r\n" +
                 "ping -n 2 127.0.0.1 >nul\r\n" + // http://stackoverflow.com/a/4317036/12916
                 "goto :loop/$)}" :
-            "node {sh 'while true; do touch " + tmp + "; sleep 1; done'}"));
+            "node {sh 'while true; do touch " + tmp + "; sleep 1; done'}", true));
 
         // get the build going, and wait until workflow pauses
         WorkflowRun b = foo.scheduleBuild2(0).getStartCondition().get();

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -114,7 +114,8 @@ public class ExecutorPickleTest {
                 SemaphoreStep.success("wait/1", null);
                 WorkflowRun b = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
                 // first prints on 2.35-: hudson.model.Messages.Queue_WaitingForNextAvailableExecutor(); 2.36+: hudson.model.Messages.Node_LabelMissing("Jenkins", "slave0")
-                r.j.waitForMessage(Messages.ExecutorPickle_waiting_to_resume(Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getFullDisplayName())), b);
+                r.j.waitForMessage(Messages.ExecutorPickle_waiting_to_resume(
+                        Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getParent().getName())), b);
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 Queue.getInstance().cancel(items[0]);
@@ -146,7 +147,8 @@ public class ExecutorPickleTest {
                 WorkflowJob p = r.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 assertFalse(p.getACL().hasPermission(Jenkins.ANONYMOUS, Item.READ));
                 WorkflowRun b = p.getBuildByNumber(1);
-                r.j.waitForMessage(Messages.ExecutorPickle_waiting_to_resume(Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getFullDisplayName())), b);
+                r.j.waitForMessage(Messages.ExecutorPickle_waiting_to_resume(
+                		Messages.ExecutorStepExecution_PlaceholderTask_displayName(b.getParent().getName())), b);
                 r.j.jenkins.getNode("remote").toComputer().setTemporarilyOffline(false, null);
                 r.j.assertBuildStatusSuccess(r.j.waitForCompletion(b));
             }


### PR DESCRIPTION
Fixes [JENKINS-52529](https://issues.jenkins-ci.org/browse/JENKINS-52529) by using the job name rather than the run's fullDisplayName as displayName for the PlaceholderTask.
As this is my very first PR I'd be glad for any input on how to improve this or possible future PRs.
