### PR TITLE
[JENKINS-28822] Distinguish between abort and failure for durable tasks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -239,6 +239,8 @@ public abstract class DurableTaskStep extends Step {
         private boolean watching; // serialized default is false
         /** Only used when {@link #watching}, if after {@link #WATCHING_RECURRENCE_PERIOD} comes around twice {@link #exited} has yet to be called. */
         private transient boolean awaitingAsynchExit;
+        /** The first throwable used to stop the task */
+        private transient volatile Throwable causeOfStoppage;
 
         Execution(StepContext context, DurableTaskStep step) {
             super(context);
@@ -350,6 +352,7 @@ public abstract class DurableTaskStep extends Step {
         }
 
         @Override public void stop(final Throwable cause) throws Exception {
+            causeOfStoppage = cause;
             FilePath workspace = getWorkspace();
             if (workspace != null) {
                 listener().getLogger().println("Sending interrupt signal to process");
@@ -503,13 +506,20 @@ public abstract class DurableTaskStep extends Step {
                 return;
             }
             recurrencePeriod = 0;
-            if (returnStatus || exitCode == 0) {
+            Throwable originalCause = causeOfStoppage;
+            if ((returnStatus && originalCause == null) || exitCode == 0) {
                 getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(output, StandardCharsets.UTF_8) : null);
             } else {
                 if (returnStdout) {
                     listener().getLogger().write(output); // diagnostic
                 }
-                getContext().onFailure(new AbortException("script returned exit code " + exitCode));
+                if (originalCause != null) {
+                    // JENKINS-28822: Use the previous cause instead of throwing a new AbortException
+                    listener().getLogger().println("script returned exit code " + exitCode);
+                    getContext().onFailure(originalCause);
+                } else {
+                    getContext().onFailure(new AbortException("script returned exit code " + exitCode));
+                }
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -294,7 +294,7 @@ public class ShellStepTest {
         p.setDefinition(new CpsFlowDefinition("node {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {" +
                 (Functions.isWindows()
-                        ? "bat 'timeout /t 5'\n"
+                        ? "bat 'ping -n 6 127.0.0.1 >nul'\n"
                         : "sh 'sleep 5'\n") +
                 "  }" +
                 "}", true));
@@ -311,7 +311,7 @@ public class ShellStepTest {
         p.setDefinition(new CpsFlowDefinition("node() {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {\n" +
                 (Functions.isWindows()
-                        ? "bat(returnStatus: true, script: 'timeout /t 5')\n)"
+                        ? "bat(returnStatus: true, script: 'ping -n 6 127.0.0.1 >nul')\n)"
                         : "sh(returnStatus: true, script: 'sleep 5')\n") +
                 "  }\n" +
                 "}", true));

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -311,7 +311,7 @@ public class ShellStepTest {
         p.setDefinition(new CpsFlowDefinition("node() {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {\n" +
                 (Functions.isWindows()
-                        ? "bat(returnStatus: true, script: 'ping -n 6 127.0.0.1 >nul')\n)"
+                        ? "bat(returnStatus: true, script: 'ping -n 6 127.0.0.1 >nul')\n"
                         : "sh(returnStatus: true, script: 'sleep 5')\n") +
                 "  }\n" +
                 "}", true));

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -288,6 +288,40 @@ public class ShellStepTest {
         
     }
 
+    @Issue("JENKINS-28822")
+    @Test public void interruptingAbortsBuild() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {\n" +
+                "  timeout(time: 1, unit: 'SECONDS') {" +
+                (Functions.isWindows()
+                        ? "bat 'timeout /t 5'\n"
+                        : "sh 'sleep 5'\n") +
+                "  }" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+        // Fails with Result.FAILURE as of commit a224295d12.
+        j.assertBuildStatus(Result.ABORTED, b);
+        j.assertLogContains("Timeout has been exceeded", b);
+    }
+
+    @Issue("JENKINS-28822")
+    @Test public void interruptingAbortsBuildEvenWithReturnStatus() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node() {\n" +
+                "  timeout(time: 1, unit: 'SECONDS') {\n" +
+                (Functions.isWindows()
+                        ? "bat(returnStatus: true, script: 'timeout /t 5')\n)"
+                        : "sh(returnStatus: true, script: 'sleep 5')\n") +
+                "  }\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+        // Succeeds as of commit a224295d12.
+        j.assertBuildStatus(Result.ABORTED, b);
+        j.assertLogContains("Timeout has been exceeded", b);
+    }
+
     /**
      * Asserts that the predicate remains true up to the given timeout.
      */


### PR DESCRIPTION
See [JENKINS-28822](https://issues.jenkins-ci.org/browse/JENKINS-28822).

This PR uses [Jesse's proposed fix](https://issues.jenkins-ci.org/browse/JENKINS-28822?focusedCommentId=305068&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-305068) of storing any `Throwable` passed to `Execution#stop` so that it can be passed to `StepContext#onFailure` in `Execution#exited` instead of creating a new `AbortException`.

I am concerned about causing regressions for anyone relying on the current behavior or for anyone using the workarounds posted in JENKINS-28822. I will test the latter, but any thoughts on the former are welcome.

- [x] Confirm that the tests pass on Windows 
- [x] Test how the behavior of the workarounds posted in JENKINS-28822 are affected by this PR (EDIT: 1 workaround doesn't appear to work in the first place, and the other is unaffected by this PR for manual aborts, and affected in the same way as not using a workaround at all for timeout-induced aborts)