### PR TITLE
[JENKINS-53837] Associate node steps with their WorkflowJob correctly after restarts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -372,7 +372,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public Queue.Task getOwnerTask() {
-            Run<?,?> r = run();
+            Run<?,?> r = runForDisplay();
             if (r != null && r.getParent() instanceof Queue.Task) {
                 return (Queue.Task) r.getParent();
             } else {


### PR DESCRIPTION
See [JENKINS-53837](https://issues.jenkins-ci.org/browse/JENKINS-53837).

This fixes an issue with custom `QueueTaskDispatcher`s trying to use `getOwnerTask` as part of their dispatching logic for restarted Pipelines.