### PR TITLE
Fix commit hashes in test comments

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -522,7 +522,7 @@ public class ShellStepTest {
                 "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(b);
-        // Fails with Result.FAILURE as of commit a224295d12.
+        // Fails with Result.FAILURE as of commit 3bd3498ba3.
         j.assertBuildStatus(Result.ABORTED, b);
         j.assertLogContains("Timeout has been exceeded", b);
     }
@@ -539,7 +539,7 @@ public class ShellStepTest {
                 "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(b);
-        // Succeeds as of commit a224295d12.
+        // Succeeds as of commit 3bd3498ba3.
         j.assertBuildStatus(Result.ABORTED, b);
         j.assertLogContains("Timeout has been exceeded", b);
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -522,7 +522,7 @@ public class ShellStepTest {
                 "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(b);
-        // Fails with Result.FAILURE as of commit 3bd3498ba3.
+        // Would have failed with Result.FAILURE before https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75.
         j.assertBuildStatus(Result.ABORTED, b);
         j.assertLogContains("Timeout has been exceeded", b);
     }
@@ -539,7 +539,7 @@ public class ShellStepTest {
                 "}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(b);
-        // Succeeds as of commit 3bd3498ba3.
+        // Would have succeeded before https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75.
         j.assertBuildStatus(Result.ABORTED, b);
         j.assertLogContains("Timeout has been exceeded", b);
     }


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75#discussion_r227280773.

@kutzi noticed that the previous commit hashes here were not correct. In fact, they were from a different repo: https://github.com/jenkinsci/durable-task-plugin/commit/a224295d12. A commit in this repo that demonstrates the previous behavior is 3bd3498ba3, and I just confirmed locally that if you check out that commit and add the new tests, they fail as described. Maybe pointless to reference commits in the first place, since it probably isn't useful to anyone, but it won't hurt either.

@reviewbybees 