### PR TITLE
[JENKINS-52165] Disable watch mode by default for now

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -31,6 +31,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
+import hudson.Main;
 import hudson.Util;
 import hudson.model.Node;
 import hudson.model.TaskListener;
@@ -170,7 +171,7 @@ public abstract class DurableTaskStep extends Step {
     /** If set to false, disables {@link Execution#watching} mode. */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable only for tests")
     @Restricted(NoExternalUse.class)
-    public static boolean USE_WATCHING = !"false".equals(System.getProperty(DurableTaskStep.class.getName() + ".USE_WATCHING"));
+    public static boolean USE_WATCHING = Boolean.parseBoolean(System.getProperty(DurableTaskStep.class.getName() + ".USE_WATCHING", Main.isUnitTest ? "true" : /* JENKINS-52165 turn back on by default */ "false"));
 
     /**
      * Represents one task that is believed to still be running.

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -541,7 +541,7 @@ public class ShellStepTest {
         j.waitForCompletion(b);
         // Would have succeeded before https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/75.
         j.assertBuildStatus(Result.ABORTED, b);
-        j.assertLogContains("Timeout has been exceeded", b);
+        j.waitForMessage("Timeout has been exceeded", b); // TODO assertLogContains fails unless a sleep is introduced; possible race condition in waitForCompletion
     }
 
     /**


### PR DESCRIPTION
Disabling #63 to buy some time until I can fix some acknowledged issues (mainly [JENKINS-54133](https://issues.jenkins-ci.org/browse/JENKINS-54133) and waiting for the maintainer on [JENKINS-54081](https://issues.jenkins-ci.org/browse/JENKINS-54081)) and properly investigate some reported issues which are likely linked ([JENKINS-54073](https://issues.jenkins-ci.org/browse/JENKINS-54073) and [JENKINS-53888](https://issues.jenkins-ci.org/browse/JENKINS-53888)). Complements https://github.com/jenkins-infra/update-center2/pull/247. https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/74 is still needed promptly since that seems to be independent.

Note that this retains watch mode in tests, to continue to enforce coverage in this plugin and in any other pkugins which currently have a test dep on 2.22+ which might bump up their dep to 2.25.