### PR TITLE
Put the onus on remote code to PrintStream.flush

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -603,6 +603,7 @@ public abstract class DurableTaskStep extends Step {
         }
 
         @Override public void exited(int code, byte[] output) throws Exception {
+            listener.getLogger().flush();
             execution.exited(code, output);
         }
 


### PR DESCRIPTION
As discussed in https://github.com/jenkinsci/workflow-api-plugin/pull/81.