### PR TITLE
Add missing overrides to fix ShellStepTest#remoteConsoleNotes

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -555,6 +555,13 @@ public class ShellStepTest {
                         }
                         logger.write(b, 0, len);
                     }
+                    @Override public void close() throws IOException {
+                        super.close();
+                        logger.close();
+                    }
+                    @Override public void flush() throws IOException {
+                        logger.flush();
+                    }
                 };
             }
         }


### PR DESCRIPTION
ShellStepTest#remoteConsoleNotes was failing in the [current CI build of master](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fworkflow-durable-task-step-plugin/detail/master/67/tests) after the buffering PR was merged.

This PR fixes the failure by adding overrides of `flush` and `close` to the `LineTransformationOutputStream` used in the test.