### PR TITLE
[JENKINS-46507] Allow timeouts for remote calls in DurableTaskStep to be configured via system property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -176,7 +176,7 @@ public abstract class DurableTaskStep extends Step {
 
     /** How many seconds to wait before interrupting remote calls and before forcing cleanup when the step is stopped */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable for script console access")
-    public static long REMOTE_TIMEOUT = Integer.parseInt(System.getProperty(DurableTaskStep.class.getName() + ".REMOTE_TIMEOUT", "10"));
+    public static long REMOTE_TIMEOUT = Integer.parseInt(System.getProperty(DurableTaskStep.class.getName() + ".REMOTE_TIMEOUT", "20"));
 
     private static ScheduledThreadPoolExecutor threadPool;
     private static synchronized ScheduledThreadPoolExecutor threadPool() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -174,7 +174,7 @@ public abstract class DurableTaskStep extends Step {
     @Restricted(NoExternalUse.class)
     public static boolean USE_WATCHING = Boolean.parseBoolean(System.getProperty(DurableTaskStep.class.getName() + ".USE_WATCHING", Main.isUnitTest ? "true" : /* JENKINS-52165 turn back on by default */ "false"));
 
-    /** How many seconds to wait before interrupting remote calls */
+    /** How many seconds to wait before interrupting remote calls and before forcing cleanup when the step is stopped */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable for script console access")
     public static long REMOTE_TIMEOUT = Integer.parseInt(System.getProperty(DurableTaskStep.class.getName() + ".REMOTE_TIMEOUT", "10"));
 
@@ -378,7 +378,7 @@ public abstract class DurableTaskStep extends Step {
                         stopTask = null;
                         if (recurrencePeriod > 0) {
                             recurrencePeriod = 0;
-                            listener().getLogger().println("After 10s process did not stop");
+                            listener().getLogger().println("After " + REMOTE_TIMEOUT + "s process did not stop");
                             getContext().onFailure(cause);
                             try {
                                 FilePath workspace = getWorkspace();
@@ -390,7 +390,7 @@ public abstract class DurableTaskStep extends Step {
                             }
                         }
                     }
-                }, 10, TimeUnit.SECONDS);
+                }, REMOTE_TIMEOUT, TimeUnit.SECONDS);
                 controller.stop(workspace, launcher());
             } else {
                 listener().getLogger().println("Could not connect to " + node + " to send interrupt signal to process");

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -174,6 +174,10 @@ public abstract class DurableTaskStep extends Step {
     @Restricted(NoExternalUse.class)
     public static boolean USE_WATCHING = Boolean.parseBoolean(System.getProperty(DurableTaskStep.class.getName() + ".USE_WATCHING", Main.isUnitTest ? "true" : /* JENKINS-52165 turn back on by default */ "false"));
 
+    /** How many seconds to wait before interrupting remote calls */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable for script console access")
+    public static long REMOTE_TIMEOUT = Integer.parseInt(System.getProperty(DurableTaskStep.class.getName() + ".REMOTE_TIMEOUT", "10"));
+
     private static ScheduledThreadPoolExecutor threadPool;
     private static synchronized ScheduledThreadPoolExecutor threadPool() {
         if (threadPool == null) {
@@ -311,7 +315,7 @@ public abstract class DurableTaskStep extends Step {
                 }
             }
             boolean directory;
-            try (Timeout timeout = Timeout.limit(10, TimeUnit.SECONDS)) {
+            try (Timeout timeout = Timeout.limit(REMOTE_TIMEOUT, TimeUnit.SECONDS)) {
                 directory = ws.isDirectory();
             } catch (Exception x) {
                 getWorkspaceProblem(x);
@@ -451,7 +455,7 @@ public abstract class DurableTaskStep extends Step {
                 return; // slave not yet ready, wait for another day
             }
             TaskListener listener = listener();
-            try (Timeout timeout = Timeout.limit(10, TimeUnit.SECONDS)) {
+            try (Timeout timeout = Timeout.limit(REMOTE_TIMEOUT, TimeUnit.SECONDS)) {
                 if (watching) {
                     Integer exitCode = controller.exitStatus(workspace, launcher(), listener);
                     if (exitCode == null) {


### PR DESCRIPTION
See [JENKINS-46507](https://issues.jenkins-ci.org/browse/JENKINS-46507).

User investigation into some cases of spuriously interrupted builds shows that slow filesystem performance during these remote calls appears to cause them to take a large amount of time to complete. 

I am waiting for more feedback to see if we should bump the default timeout (right now the user investigating the issue is testing with a 10-minute timeout which seems a little too long for most cases), but I think it would be helpful to allow users to increase this timeout by system property if necessary.

@reviewbybees 