### PR TITLE
[JENKINS-55410] Added label attribute for documentation and clarity in jenkins views

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -65,6 +65,8 @@ import org.jenkinsci.plugins.durabletask.Controller;
 import org.jenkinsci.plugins.durabletask.DurableTask;
 import org.jenkinsci.plugins.durabletask.Handler;
 import org.jenkinsci.plugins.workflow.FilePathUtils;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -95,6 +97,7 @@ public abstract class DurableTaskStep extends Step {
     private boolean returnStdout;
     private String encoding;
     private boolean returnStatus;
+    private String label;
 
     protected abstract DurableTask task();
 
@@ -121,8 +124,19 @@ public abstract class DurableTaskStep extends Step {
     @DataBoundSetter public void setReturnStatus(boolean returnStatus) {
         this.returnStatus = returnStatus;
     }
+    
+    @DataBoundSetter public void setLabel(String label) {
+        this.label = label;
+    }
+    
+    public String getLabel() {
+        return label;
+    }
 
     @Override public StepExecution start(StepContext context) throws Exception {
+        if (this.label != null && !this.label.isEmpty()) {
+            context.get(FlowNode.class).addAction(new LabelAction(this.label));
+        }
         return new Execution(context, this);
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/config.jelly
@@ -36,5 +36,8 @@ THE SOFTWARE.
         <f:entry field="returnStatus" title="${%Return exit status}">
             <f:checkbox/>
         </f:entry>
+        <f:entry field="label" title="${%Label}">
+            <f:textbox/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-label.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep/help-label.html
@@ -1,0 +1,4 @@
+<div>
+    Label to be displayed in the pipeline step view and blue ocean details for the step instead of the step type.
+    So the view is more meaningful and domain specific instead of technical.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -276,6 +276,8 @@ public class ShellStepTest {
         assertFalse(s.isReturnStdout());
         assertNull(s.getEncoding());
         assertFalse(s.isReturnStatus());
+        assertEquals("", s.getLabel());
+        
         s.setReturnStdout(true);
         s.setEncoding("ISO-8859-1");
         s = new StepConfigTester(j).configRoundTrip(s);
@@ -283,6 +285,8 @@ public class ShellStepTest {
         assertTrue(s.isReturnStdout());
         assertEquals("ISO-8859-1", s.getEncoding());
         assertFalse(s.isReturnStatus());
+        assertEquals("", s.getLabel());
+        
         s.setReturnStdout(false);
         s.setEncoding("UTF-8");
         s.setReturnStatus(true);
@@ -291,6 +295,15 @@ public class ShellStepTest {
         assertFalse(s.isReturnStdout());
         assertEquals("UTF-8", s.getEncoding());
         assertTrue(s.isReturnStatus());
+        assertEquals("", s.getLabel());
+        
+        s.setLabel("Round Trip Test");
+        s = new StepConfigTester(j).configRoundTrip(s);
+        assertEquals("echo hello", s.getScript());
+        assertFalse(s.isReturnStdout());
+        assertEquals("UTF-8", s.getEncoding());
+        assertTrue(s.isReturnStatus());
+        assertEquals("Round Trip Test", s.getLabel());
     }
 
     @Issue("JENKINS-26133")
@@ -308,6 +321,26 @@ public class ShellStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {echo \"truth is ${isUnix() ? sh(script: 'true', returnStatus: true) : bat(script: 'echo', returnStatus: true)} but falsity is ${isUnix() ? sh(script: 'false', returnStatus: true) : bat(script: 'type nonexistent' , returnStatus: true)}\"}", true));
         j.assertLogContains("truth is 0 but falsity is 1", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+    
+    
+    @Test public void label() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {isUnix() ? sh(script: 'true', label: 'Step with label') : bat(script: 'echo', label: 'Step with label')}", true));
+        
+        WorkflowRun b = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        boolean found = false;
+        FlowGraphTable t = new FlowGraphTable(b.getExecution());
+        t.build();
+        for (Row r : t.getRows()) {
+            if (r.getDisplayName().equals("Step with label")) {
+                found = true;
+            }
+        }
+
+        assertTrue(found);
+        
     }
 
     @Issue("JENKINS-38381")


### PR DESCRIPTION
See [JENKINS-55410](https://issues.jenkins-ci.org/browse/JENKINS-55410).

I've added an new Attribute "label" to the durable steps, so that this is displayed within the pipeline steps view and blue ocean views instead of the technical Name "Windows Batch Script" or "Linux Shell script". We have got a lot of this and it is very hard to find the right one. 

With this labels this step can now display the real domain specific information for example "build manual" "copy driver files" etc. This makes the pipeline views very more comfortable to use.
