### PR TITLE
[JENKINS-52165] Do not enable watch mode automatically in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.24</version>
+        <version>3.33</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -31,7 +31,6 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
-import hudson.Main;
 import hudson.Util;
 import hudson.init.Terminator;
 import hudson.model.Node;
@@ -196,7 +195,7 @@ public abstract class DurableTaskStep extends Step {
     /** If set to false, disables {@link Execution#watching} mode. */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable only for tests")
     @Restricted(NoExternalUse.class)
-    public static boolean USE_WATCHING = Boolean.parseBoolean(System.getProperty(DurableTaskStep.class.getName() + ".USE_WATCHING", Main.isUnitTest ? "true" : /* JENKINS-52165 turn back on by default */ "false"));
+    public static boolean USE_WATCHING = Boolean.getBoolean(DurableTaskStep.class.getName() + ".USE_WATCHING"); // JENKINS-52165: turn back on by default
 
     private static ScheduledThreadPoolExecutor threadPool;
     private static synchronized ScheduledThreadPoolExecutor threadPool() {


### PR DESCRIPTION
Besides the original discussion in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/84#discussion_r227798017, I found that watch mode was being activated in JFR “serverless” builds, including Jenkins X in `--prow` mode, due to [this questionable behavior](https://github.com/jenkinsci/jenkinsfile-runner/blob/6ca2605ea48a4c186ed48d16dcbb5db8551b5b54/setup/src/main/java/io/jenkins/jenkinsfile/runner/JenkinsEmbedder.java#L654-L655). Probably less surprising to enable watch mode only when tests explicitly ask for it.

I considered making some of these test suites `Parameterized` but they were already pretty long-running and it looked complicated: some tests only make sense in watch mode or vice-versa, so was not sure whether this would be desirable.