### PR TITLE
Reproduced a problem with shell output missing a final newline wrapped in a LineTransformationOutputStream

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import javax.annotation.CheckForNull;
@@ -82,8 +83,10 @@ import static org.junit.Assert.*;
 import org.junit.Assume;
 import static org.junit.Assume.assumeFalse;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ErrorCollector;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -101,7 +104,7 @@ public class ShellStepTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
-
+    @Rule public ErrorCollector errors = new ErrorCollector();
     @Rule public LoggerRule logging = new LoggerRule();
 
     /**
@@ -594,6 +597,44 @@ public class ShellStepTest {
         ws.child("message").write("¡Čau → there!\n", "UTF-8");
         p.setDefinition(new CpsFlowDefinition("node('remote') {if (isUnix()) {sh script: 'cat message', encoding: 'UTF-8'} else {bat script: 'type message', encoding: 'UTF-8'}}", true));
         j.assertLogContains("¡Čau → there!", j.buildAndAssertSuccess(p));
+    }
+
+    @Ignore("TODO missing final line and in some cases even the `+ set +x` (but passes without withCredentials)")
+    @Test public void missingNewline() throws Exception {
+        assumeFalse(Functions.isWindows()); // TODO create Windows equivalent
+        String credentialsId = "creds";
+        String username = "bob";
+        String password = "s3cr3t";
+        UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+        j.createSlave("remote", null, null);
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node('master') {\n" +
+            "  withCredentials([usernameColonPassword(variable: 'USERPASS', credentialsId: '" + credentialsId + "')]) {\n" +
+            "    sh 'set +x; printf \"some local output\"'\n" +
+            "  }\n" +
+            "}\n" +
+            "node('remote') {\n" +
+            "  withCredentials([usernameColonPassword(variable: 'USERPASS', credentialsId: '" + credentialsId + "')]) {\n" +
+            "    sh 'set +x; printf \"some remote output\"'\n" +
+            "  }\n" +
+            "}", true));
+        Callable<Void> test = () -> {
+            WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            j.assertLogContains("some local output", b);
+            j.assertLogContains("some remote output", b);
+            return null;
+        };
+        boolean origUseWatching = DurableTaskStep.USE_WATCHING;
+        try {
+            DurableTaskStep.USE_WATCHING = false;
+            errors.checkSucceeds(test);
+            DurableTaskStep.USE_WATCHING = true;
+            errors.checkSucceeds(test);
+        } finally {
+            DurableTaskStep.USE_WATCHING = origUseWatching;
+        }
     }
 
     @Issue("JENKINS-34021")


### PR DESCRIPTION
Not sure how long this has been broken; I assume it is related to JEP-210 in that the issue is a `TaskListener` per step.

Despite https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/85 this fails with or without watch mode. Calling `flush()` on the stream does not suffice because `LineTransformationOutputStream` (as used in `BindingStep` and many other places) does not then `forceEol`. This fixes the test in default poll mode, though it makes me nervous because I would need to research whether per-step listeners may safely be closed:

```diff
diff --git a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
index 1f8ca2b..3162ebc 100644
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -548,6 +548,7 @@ public abstract class DurableTaskStep extends Step {
         private void handleExit(int exitCode, OutputSupplier output) throws IOException, InterruptedException {
             Throwable originalCause = causeOfStoppage;
             if ((returnStatus && originalCause == null) || exitCode == 0) {
+                listener().getLogger().close();
                 getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(output.produce(), StandardCharsets.UTF_8) : null);
             } else {
                 if (returnStdout) {
```

This fixes only on-master output in watch mode, for unknown reasons probably related to the missing `+ set +x`:

```diff
@@ -640,7 +641,7 @@ public abstract class DurableTaskStep extends Step {
         }
 
         @Override public void exited(int code, byte[] output) throws Exception {
-            listener.getLogger().flush();
+            listener.getLogger().close();
             execution.exited(code, output);
         }
 
```