### PR TITLE
[JENKINS-49707] (part): Fail the build if an agent has been removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43-20190430.202429-2</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/196 -->
+        <version>3.43</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.40</version>
+        <version>3.43-20190430.202429-2</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/196 -->
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -340,7 +340,7 @@ public abstract class DurableTaskStep extends Step {
                     // (Note that a Computer may be missing because a Node is offline,
                     // and conversely after removing a Node its Computer may remain for a while.
                     // Therefore we only fail here if _both_ are absent.)
-                    // ExecutorStepExecution.NodeListener will normally do this first, so this is a fallback.
+                    // ExecutorStepExecution.RemovedNodeListener will normally do this first, so this is a fallback.
                     Jenkins j = Jenkins.getInstanceOrNull();
                     if (ExecutorStepExecution.RemovedNodeCause.ENABLED && !node.isEmpty() && j != null && j.getNode(node) == null) {
                         if (removedNodeDiscovered == 0) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -334,7 +334,7 @@ public abstract class DurableTaskStep extends Step {
                     // Therefore we only fail here if _both_ are absent.)
                     // ExecutorStepExecution.NodeListener will normally do this first, so this is a fallback.
                     Jenkins j = Jenkins.getInstanceOrNull();
-                    if (!node.isEmpty() && j != null && j.getNode(node) == null) {
+                    if (ExecutorStepExecution.RemovedNodeCause.ENABLED && !node.isEmpty() && j != null && j.getNode(node) == null) {
                         if (removedNodeDiscovered == 0) {
                             LOGGER.fine(() -> "discovered that " + node + " has been removed");
                             removedNodeDiscovered = System.nanoTime();

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -347,7 +347,7 @@ public abstract class DurableTaskStep extends Step {
                             LOGGER.fine(() -> "discovered that " + node + " has been removed");
                             removedNodeDiscovered = System.nanoTime();
                             return null;
-                        } else if (System.nanoTime() < removedNodeDiscovered + TimeUnit.MILLISECONDS.toNanos(ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS)) {
+                        } else if (System.nanoTime() - removedNodeDiscovered < TimeUnit.MILLISECONDS.toNanos(ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS)) {
                             LOGGER.fine(() -> "rediscovering that " + node + " has been removed");
                             return null;
                         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.support.pickles;
 import com.google.common.util.concurrent.ListenableFuture;
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Main;
 import hudson.model.Executor;
 import hudson.model.Node;
 import hudson.model.OneOffExecutor;
@@ -47,6 +48,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.pickles.Pickle;
 import org.jenkinsci.plugins.workflow.steps.durable_task.Messages;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Persists an {@link Executor} as the {@link hudson.model.Queue.Task} it was running.
@@ -62,7 +65,8 @@ public class ExecutorPickle extends Pickle {
 
     private final boolean isEphemeral;
 
-    static long TIMEOUT_WAITING_FOR_NODE_MILLIS = Long.getLong(ExecutorPickle.class.getName()+".timeoutForNodeMillis", TimeUnit.MINUTES.toMillis(5));
+    @Restricted(NoExternalUse.class)
+    public static long TIMEOUT_WAITING_FOR_NODE_MILLIS = Main.isUnitTest ? /* fail faster */ TimeUnit.SECONDS.toMillis(15) : Long.getLong(ExecutorPickle.class.getName()+".timeoutForNodeMillis", TimeUnit.MINUTES.toMillis(5));
 
     private ExecutorPickle(Executor executor) {
         if (executor instanceof OneOffExecutor) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.support.pickles;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Main;
@@ -65,6 +66,7 @@ public class ExecutorPickle extends Pickle {
 
     private final boolean isEphemeral;
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "deliberately mutable")
     @Restricted(NoExternalUse.class)
     public static long TIMEOUT_WAITING_FOR_NODE_MILLIS = Main.isUnitTest ? /* fail faster */ TimeUnit.SECONDS.toMillis(15) : Long.getLong(ExecutorPickle.class.getName()+".timeoutForNodeMillis", TimeUnit.MINUTES.toMillis(5));
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -255,6 +255,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
     @Extension public static final class RemovedNodeListener extends NodeListener {
         @Override protected void onDeleted(Node node) {
+            if (!RemovedNodeCause.ENABLED) {
+                return;
+            }
             LOGGER.fine(() -> "received node deletion event on " + node.getNodeName());
             Timer.get().schedule(() -> {
                 Computer c = node.toComputer();
@@ -286,6 +289,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
     }
 
     public static final class RemovedNodeCause extends CauseOfInterruption {
+        @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "deliberately mutable")
+        public static boolean ENABLED = Boolean.parseBoolean(System.getProperty(ExecutorStepExecution.class.getName() + ".REMOVED_NODE_DETECTION", "true"));
         @Override public String getShortDescription() {
             return "Agent was removed";
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -77,6 +77,7 @@ import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable.Row;
 import static org.junit.Assert.*;
@@ -614,15 +615,15 @@ public class ShellStepTest {
     
     @Issue("JENKINS-49707")
     @Test public void removingAgentIsFatal() throws Exception {
-        logging.record(DurableTaskStep.class, Level.FINE).record(FileMonitoringTask.class, Level.FINE);
+        logging.record(DurableTaskStep.class, Level.FINE).record(FileMonitoringTask.class, Level.FINE).record(ExecutorStepExecution.class, Level.FINE);
         DumbSlave s = j.createSlave("remote", null, null);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('remote') {isUnix() ? sh('sleep 1000000') : bat('ping -t 127.0.0.1 > nul')}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
         j.jenkins.removeNode(s);
-        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b));
-        j.assertLogContains("Agent remote was removed", b);
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
+        j.waitForMessage(new ExecutorStepExecution.RemovedNodeCause().getShortDescription(), b);
     }
 
     @Issue("JENKINS-44521")

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -191,7 +191,6 @@ public class ExecutorPickleTest {
                 DumbSlave s = r.j.createSlave(Label.get("ghost"));
                 System.out.println("Agent launched, waiting for semaphore");
                 SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
-                ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS = 4000L; // fail faster
                 r.j.jenkins.removeNode(s);
             }
         });
@@ -199,7 +198,6 @@ public class ExecutorPickleTest {
         r.addStep(new Statement() {
             // Start up a build and then reboot and take the node offline
             @Override public void evaluate() throws Throwable {
-                ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS = 4000L; // fail faster
                 assertEquals(0, r.j.jenkins.getLabel("ghost").getNodes().size()); // Make sure test impl is correctly deleted
                 assertNull(r.j.jenkins.getNode("ghost")); // Make sure test impl is correctly deleted
                 WorkflowRun run = r.j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();


### PR DESCRIPTION
Improved behavior for one subcase of [JENKINS-49707](https://issues.jenkins-ci.org/browse/JENKINS-49707), that a disconnected agent is actually removed from Jenkins configuration for whatever reason. We assume that it is not going to be readded (under the same name), so there is no point in waiting for it to reconnect. ~The one exception that I know of is that a Swarm agent [will remove itself upon disconnect](https://github.com/jenkinsci/swarm-plugin/blob/796a04914e986f0fe6ab720e2cc95169831251dc/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java#L89) but [might readd itself later](https://github.com/jenkinsci/swarm-plugin/blob/796a04914e986f0fe6ab720e2cc95169831251dc/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java#L219), so this might break cross-disconnect durability of Pipeline builds for Swarm, but that seems like a far less likely case than typical `Cloud`s.~

#47 and #48 do something similar across Jenkins restarts. I think the `TIMEOUT_WAITING_FOR_NODE_MILLIS` grace period there is irrelevant here, since that would be done before the program even resumes.

- [x] decide about `FAILURE` vs. `ABORTED` status
- [ ] ~test on EC2 with spot instances~ did not manage to set up the `ec2` plugin successfully
- [x] test against `kubernetes` plugin with a killed pod
- [x] consider implementing instead in `ExecutorStepExecution` (would work not just for `DurableTaskStep`)

@schottsfired