### PR TITLE
Added EXECUTOR_COUNT to environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -758,6 +758,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             env.put("NODE_NAME", label);
                         }
                         env.put("EXECUTOR_NUMBER", String.valueOf(exec.getNumber()));
+                        env.put("EXECUTOR_COUNT", String.valueOf(computer.countExecutors()));
                         env.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
 
                         synchronized (runningTasks) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -100,6 +100,29 @@ public class EnvWorkflowTest {
         r.assertLogContains("My number on a slave is 0", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 
+    /**
+     * Verifies if EXECUTOR_COUNT environemn variable is set
+     */
+    @Test public void isExecutorCountAvailable() throws Exception {
+        r.jenkins.setNumExecutors(2);
+        r.createSlave("node-test", null, null);
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('master') {\n" +
+                        "  echo \"My number on master is ${env.EXECUTOR_COUNT}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My number on master is 2", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node('node-test') {\n" +
+                        "  echo \"My number on a slave is ${env.EXECUTOR_COUNT}\"\n" +
+                        "}\n"
+        ));
+        r.assertLogContains("My number on a slave is 1", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+    }
+
     @Issue("JENKINS-33511")
     @Test public void isWorkspaceAvailable() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");


### PR DESCRIPTION
It may be reasonable to check executor count of currently used master/slave agent. This PR exposes this as environment variable.