### PR TITLE
Use an LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.32</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176</jenkins.version>
+        <jenkins.version>2.176.1</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>


### PR DESCRIPTION
Amends #102 to use an actual LTS version, not just the baseline, in case this has some effect on update site calculations (weekly vs. LTS).