### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -53,23 +53,23 @@ public class EnvWorkflowTest {
         p.setDefinition(new CpsFlowDefinition(
             "node('master') {\n" +
             "  echo \"My name on master is ${env.NODE_NAME} using labels ${env.NODE_LABELS}\"\n" +
-            "}\n"
-        ));
+            "}\n",
+            true));
         r.assertLogContains("My name on master is master using labels master", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
 
         p.setDefinition(new CpsFlowDefinition(
             "node('node-test') {\n" +
             "  echo \"My name on a slave is ${env.NODE_NAME} using labels ${env.NODE_LABELS}\"\n" +
-            "}\n"
-        ));
+            "}\n",
+            true));
         // Label.parse returns TreeSet so the result is guaranteed to be sorted:
         r.assertLogContains("My name on a slave is node-test using labels fast node-test unix", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
 
         p.setDefinition(new CpsFlowDefinition( // JENKINS-41446 ensure variable still available in a ws step
             "node('node-test') {\n ws('workspace/foo') {" +
             "    echo \"My name on a slave is ${env.NODE_NAME} using labels ${env.NODE_LABELS}\"\n" +
-            "  }\n}\n"
-        ));
+            "  }\n}\n",
+            true));
         // Label.parse returns TreeSet so the result is guaranteed to be sorted:
         r.assertLogContains("My name on a slave is node-test using labels fast node-test unix", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
@@ -88,15 +88,15 @@ public class EnvWorkflowTest {
         p.setDefinition(new CpsFlowDefinition(
                 "node('master') {\n" +
                         "  echo \"My number on master is ${env.EXECUTOR_NUMBER}\"\n" +
-                        "}\n"
-        ));
+                        "}\n",
+                true));
         r.assertLogContains("My number on master is 0", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
 
         p.setDefinition(new CpsFlowDefinition(
                 "node('node-test') {\n" +
                         "  echo \"My number on a slave is ${env.EXECUTOR_NUMBER}\"\n" +
-                        "}\n"
-        ));
+                        "}\n",
+                true));
         r.assertLogContains("My number on a slave is 0", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowerShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowerShellStepTest.java
@@ -45,7 +45,7 @@ public class PowerShellStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "pretest");
         p.setDefinition(new CpsFlowDefinition(Functions.isWindows() ?
         "node { bat('powershell.exe -ExecutionPolicy Bypass -NonInteractive -Command \"if ($PSVersionTable.PSVersion.Major -ge 3) {exit 0} else {exit 1}\"') }" :
-        "node { sh('powershell -NonInteractive -Command \"if ($PSVersionTable.PSVersion.Major -ge 3) {exit 0} else {exit 1}\"') }"));
+        "node { sh('powershell -NonInteractive -Command \"if ($PSVersionTable.PSVersion.Major -ge 3) {exit 0} else {exit 1}\"') }", true));
         WorkflowRun b = p.scheduleBuild2(0).get();
         Result r = b.getResult();
         Assume.assumeTrue("This test should only run if the pretest workflow job succeeded", r == Result.SUCCESS);
@@ -54,20 +54,20 @@ public class PowerShellStepTest {
     // Test that a powershell step producing particular output indeed has a log containing that output
     @Test public void testOutput() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "foo");
-        p.setDefinition(new CpsFlowDefinition("node {powershell 'Write-Output \"a moon full of stars and astral cars\"'}"));
+        p.setDefinition(new CpsFlowDefinition("node {powershell 'Write-Output \"a moon full of stars and astral cars\"'}", true));
         j.assertLogContains("a moon full of stars and astral cars", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
     
     // Test that a powershell step that fails indeed causes the underlying build to fail
     @Test public void testFailure() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "bar");
-        p.setDefinition(new CpsFlowDefinition("node {powershell 'throw \"bogus error\"'}"));
+        p.setDefinition(new CpsFlowDefinition("node {powershell 'throw \"bogus error\"'}", true));
         j.assertLogContains("bogus error", j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
     }
     
     @Test public void testUnicode() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "foobar");
-        p.setDefinition(new CpsFlowDefinition("node {def x = powershell(returnStdout: true, script: 'write-output \"Hëllö Wórld\"'); println x.replace(\"\ufeff\",\"\")}"));
+        p.setDefinition(new CpsFlowDefinition("node {def x = powershell(returnStdout: true, script: 'write-output \"Hëllö Wórld\"'); println x.replace(\"\ufeff\",\"\")}", true));
         String log = new String(j.getLog(j.assertBuildStatusSuccess(p.scheduleBuild2(0))).getBytes(), "UTF-8");
         Assume.assumeTrue("Correct UTF-8 output should be produced",log.contains("Hëllö Wórld"));
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -116,7 +116,7 @@ public class ShellStepTest {
     public void failureShouldMarkNodeRed() throws Exception {
         // job setup
         WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo");
-        foo.setDefinition(new CpsFlowDefinition(Functions.isWindows() ? "node {bat 'whatever'}" : "node {sh 'false'}"));
+        foo.setDefinition(new CpsFlowDefinition(Functions.isWindows() ? "node {bat 'whatever'}" : "node {sh 'false'}", true));
 
         // get the build going, and wait until workflow pauses
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, foo.scheduleBuild2(0).get());
@@ -178,7 +178,7 @@ public class ShellStepTest {
                 "echo . >" + tmp + "\r\n" +
                 "ping -n 2 127.0.0.1 >nul\r\n" + // http://stackoverflow.com/a/4317036/12916
                 "goto :loop/$)}" :
-            "node {sh 'while true; do touch " + tmp + "; sleep 1; done'}"));
+            "node {sh 'while true; do touch " + tmp + "; sleep 1; done'}", true));
 
         // get the build going, and wait until workflow pauses
         WorkflowRun b = foo.scheduleBuild2(0).getStartCondition().get();
@@ -223,11 +223,11 @@ public class ShellStepTest {
     @Test public void launcherDecorator() throws Exception {
         Assume.assumeTrue("TODO Windows equivalent TBD", new File("/usr/bin/nice").canExecute());
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node {sh 'echo niceness=`nice`'}"));
+        p.setDefinition(new CpsFlowDefinition("node {sh 'echo niceness=`nice`'}", true));
         Assume.assumeThat("test only works if mvn test is not itself niced", j.getLog(j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsString("niceness=0"));
-        p.setDefinition(new CpsFlowDefinition("node {nice {sh 'echo niceness=`nice`'}}"));
+        p.setDefinition(new CpsFlowDefinition("node {nice {sh 'echo niceness=`nice`'}}", true));
         j.assertLogContains("niceness=10", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
-        p.setDefinition(new CpsFlowDefinition("node {nice {nice {sh 'echo niceness=`nice`'}}}"));
+        p.setDefinition(new CpsFlowDefinition("node {nice {nice {sh 'echo niceness=`nice`'}}}", true));
         j.assertLogContains("niceness=19", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
     }
     public static class NiceStep extends AbstractStepImpl {
@@ -313,7 +313,7 @@ public class ShellStepTest {
     @Test public void returnStdout() throws Exception {
         Assume.assumeTrue("TODO Windows equivalent TBD", new File("/usr/bin/tr").canExecute());
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("def msg; node {msg = sh(script: 'echo hello world | tr [a-z] [A-Z]', returnStdout: true).trim()}; echo \"it said ${msg}\""));
+        p.setDefinition(new CpsFlowDefinition("def msg; node {msg = sh(script: 'echo hello world | tr [a-z] [A-Z]', returnStdout: true).trim()}; echo \"it said ${msg}\"", true));
         j.assertLogContains("it said HELLO WORLD", j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
         p.setDefinition(new CpsFlowDefinition("node {sh script: 'echo some problem here | tr [a-z] [A-Z]; exit 1', returnStdout: true}", true));
         j.assertLogContains("SOME PROBLEM HERE", j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -523,7 +523,7 @@ public class ExecutorStepTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "demo");
-                p.setDefinition(new CpsFlowDefinition("node('special') {echo 'OK ran'}"));
+                p.setDefinition(new CpsFlowDefinition("node('special') {echo 'OK ran'}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 story.j.waitForMessage("Still waiting to schedule task", b);
             }
@@ -547,7 +547,7 @@ public class ExecutorStepTest {
                 p.setDefinition(new CpsFlowDefinition(
                     "node('dumbo') {\n" +
                     "  semaphore 'wait'\n" +
-                    "}"));
+                    "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
                 dumbo.getComputer().setTemporarilyOffline(true, new OfflineCause.UserCause(User.getUnknown(), "not about to reconnect"));
@@ -578,7 +578,7 @@ public class ExecutorStepTest {
                         "node('" + s.getNodeName() + "') {\n"
                         + "semaphore 'wait'\n"
                         + "    sleep 10\n"
-                        + "}"));
+                        + "}", true));
 
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
@@ -610,9 +610,9 @@ public class ExecutorStepTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "demo");
-                p.setDefinition(new CpsFlowDefinition("def r = node {'the result'}; echo \"got ${r}\""));
+                p.setDefinition(new CpsFlowDefinition("def r = node {'the result'}; echo \"got ${r}\"", true));
                 story.j.assertLogContains("got the result", story.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
-                p.setDefinition(new CpsFlowDefinition("try {node {error 'a problem'}} catch (e) {echo \"failed with ${e.message}\"}"));
+                p.setDefinition(new CpsFlowDefinition("try {node {error 'a problem'}} catch (e) {echo \"failed with ${e.message}\"}", true));
                 story.j.assertLogContains("failed with a problem", story.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
             }
         });
@@ -722,7 +722,7 @@ public class ExecutorStepTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "demo");
-                p.setDefinition(new CpsFlowDefinition("for (int i = 0; i < 50; i++) {node {echo \"ran node block #${i}\"}}"));
+                p.setDefinition(new CpsFlowDefinition("for (int i = 0; i < 50; i++) {node {echo \"ran node block #${i}\"}}", true));
                 story.j.assertLogContains("ran node block #49", story.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
             }
         });


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't consistently use the script security sandbox. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production. In this change, I replaced any usages of the deprecated single-argument constructor for `CpsFlowDefinition` with usages of the non-deprecated two-argument constructor, passing in `true` as the second argument in order to always enable the script security sandbox.