### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ComputerPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ComputerPickle.java
@@ -50,7 +50,7 @@ public class ComputerPickle extends Pickle {
             @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
             @Override
             protected Computer tryResolve() {
-                Jenkins j = Jenkins.getInstance();
+                Jenkins j = Jenkins.getInstanceOrNull();
                 if (j == null) {
                     return null;
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -125,7 +125,7 @@ public class ExecutorPickle extends Pickle {
                         // PlaceholderTask#getAssignedLabel is set to the Node name when execution starts
                         // Thus we're guaranteeing the execution began and the Node is now unknown.
                         // Theoretically it's safe to simply fail earlier when rehydrating any EphemeralNode... but we're being extra safe.
-                        if (placeholder.getCookie() != null && Jenkins.getActiveInstance().getNode(placeholder.getAssignedLabel().getName()) == null ) {
+                        if (placeholder.getCookie() != null && Jenkins.get().getNode(placeholder.getAssignedLabel().getName()) == null ) {
                             if (System.nanoTime() > endTimeNanos) {
                                 Queue.getInstance().cancel(item);
                                     throw new AbortException(MessageFormat.format("Killed {0} after waiting for {1} ms because we assume unknown Node {2} is never going to appear!",

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/WorkspaceListLeasePickle.java
@@ -51,7 +51,7 @@ public class WorkspaceListLeasePickle extends Pickle {
         return new TryRepeatedly<WorkspaceList.Lease>(1) {
             @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
             @Override protected WorkspaceList.Lease tryResolve() throws InterruptedException {
-                Jenkins j = Jenkins.getInstance();
+                Jenkins j = Jenkins.getInstanceOrNull();
                 if (j == null) {
                     return null;
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep.java
@@ -98,7 +98,7 @@ public final class ExecutorStep extends Step implements Serializable {
         // TODO copied from AbstractProjectDescriptor
         public AutoCompletionCandidates doAutoCompleteLabel(@QueryParameter String value) {
             AutoCompletionCandidates c = new AutoCompletionCandidates();
-            Jenkins j = Jenkins.getInstance();
+            Jenkins j = Jenkins.getInstanceOrNull();
             if (j != null) {
                 for (Label label : j.getLabels()) {
                     if (label.getName().startsWith(value)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -499,11 +499,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         public @CheckForNull Run<?,?> runForDisplay() {
             Run<?,?> r = run();
             if (r == null && /* not stored prior to 1.13 */runId != null) {
-                SecurityContext orig = ACL.impersonate(ACL.SYSTEM);
-                try {
+                try (ACLContext context = ACL.as(ACL.SYSTEM)) {
                     return Run.fromExternalizableId(runId);
-                } finally {
-                    SecurityContextHolder.setContext(orig);
                 }
             }
             return r;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -156,7 +156,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 LOGGER.log(FINE, "no match on {0}", item);
             }
         }
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.getInstanceOrNull();
         if (j != null) {
             // if we are already running, kill the ongoing activities, which releases PlaceholderExecutable from its sleep loop
             // Similar to Executor.of, but distinct since we do not have the Executable yet:
@@ -193,7 +193,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     return;
                 }
             }
-            Jenkins j = Jenkins.getInstance();
+            Jenkins j = Jenkins.getInstanceOrNull();
             if (j != null) {
                 COMPUTERS: for (Computer c : j.getComputers()) {
                     for (Executor e : c.getExecutors()) {
@@ -224,7 +224,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return "waiting for " + item.task.getFullDisplayName() + " to be scheduled; blocked: " + item.getWhy();
             }
         }
-        Jenkins j = Jenkins.getInstance();
+        Jenkins j = Jenkins.getInstanceOrNull();
         if (j != null) {
             COMPUTERS: for (Computer c : j.getComputers()) {
                 for (Executor e : c.getExecutors()) {
@@ -384,12 +384,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return cookie;
         }
 
-        @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
         @Override public Label getAssignedLabel() {
             if (label == null) {
                 return null;
             } else if (label.isEmpty()) {
-                Jenkins j = Jenkins.getInstance();
+                Jenkins j = Jenkins.getInstanceOrNull();
                 if (j == null) {
                     return null;
                 }
@@ -399,12 +398,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
         }
 
-        @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", justification="TODO 1.653+ switch to Jenkins.getInstanceOrNull")
         @Override public Node getLastBuiltOn() {
             if (label == null) {
                 return null;
             }
-            Jenkins j = Jenkins.getInstance();
+            Jenkins j = Jenkins.getInstanceOrNull();
             if (j == null) {
                 return null;
             }
@@ -960,7 +958,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 if (r == null) {
                     return "";
                 }
-                Jenkins j = Jenkins.getInstance();
+                Jenkins j = Jenkins.getInstanceOrNull();
                 String base = "";
                 if (j != null) {
                     base = Util.removeTrailingSlash(j.getRootUrl()) + "/";

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -457,21 +457,21 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         @Override public ACL getACL() {
             try {
                 if (!context.isReady()) {
-                    return Jenkins.getActiveInstance().getACL();
+                    return Jenkins.get().getACL();
                 }
                 FlowExecution exec = context.get(FlowExecution.class);
                 if (exec == null) {
-                    return Jenkins.getActiveInstance().getACL();
+                    return Jenkins.get().getACL();
                 }
                 Queue.Executable executable = exec.getOwner().getExecutable();
                 if (executable instanceof AccessControlled) {
                     return ((AccessControlled) executable).getACL();
                 } else {
-                    return Jenkins.getActiveInstance().getACL();
+                    return Jenkins.get().getACL();
                 }
             } catch (Exception x) {
                 LOGGER.log(FINE, null, x);
-                return Jenkins.getActiveInstance().getACL();
+                return Jenkins.get().getACL();
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -110,7 +110,7 @@ public class ExecutorPickleTest {
                 WorkflowJob p = r.j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition("node('remote') {semaphore 'wait'}", true));
                 SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
-                remote.toComputer().setTemporarilyOffline(true, new OfflineCause.UserCause(User.get("admin"), "hold"));
+                remote.toComputer().setTemporarilyOffline(true, new OfflineCause.UserCause(User.getById("admin", true), "hold"));
             }
         });
         r.addStep(new Statement() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -628,14 +628,14 @@ public class ExecutorStepTest {
                 p.setDefinition(new CpsFlowDefinition("node('nonexistent') {}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 story.j.waitForMessage("Still waiting to schedule task", b);
-                ACL.impersonate(User.get("admin").impersonate(), new Runnable() {
+                ACL.impersonate(User.getById("admin", true).impersonate(), new Runnable() {
                     @Override public void run() {
                         Queue.Item[] items = Queue.getInstance().getItems();
                         assertEquals(1, items.length); // fails in 1.638
                         assertEquals(p, items[0].task.getOwnerTask());
                     }
                 });
-                ACL.impersonate(User.get("devel").impersonate(), new Runnable() {
+                ACL.impersonate(User.getById("devel", true).impersonate(), new Runnable() {
                     @Override public void run() {
                         Queue.Item[] items = Queue.getInstance().getItems();
                         assertEquals(0, items.length); // fails in 1.609.2

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -43,6 +43,7 @@ import hudson.model.queue.QueueTaskDispatcher;
 import hudson.remoting.Launcher;
 import hudson.remoting.Which;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.JNLPLauncher;
@@ -628,19 +629,15 @@ public class ExecutorStepTest {
                 p.setDefinition(new CpsFlowDefinition("node('nonexistent') {}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 story.j.waitForMessage("Still waiting to schedule task", b);
-                ACL.impersonate(User.getById("admin", true).impersonate(), new Runnable() {
-                    @Override public void run() {
-                        Queue.Item[] items = Queue.getInstance().getItems();
-                        assertEquals(1, items.length); // fails in 1.638
-                        assertEquals(p, items[0].task.getOwnerTask());
-                    }
-                });
-                ACL.impersonate(User.getById("devel", true).impersonate(), new Runnable() {
-                    @Override public void run() {
-                        Queue.Item[] items = Queue.getInstance().getItems();
-                        assertEquals(0, items.length); // fails in 1.609.2
-                    }
-                });
+                try (ACLContext context = ACL.as(User.getById("admin", true))) {
+                    Queue.Item[] items = Queue.getInstance().getItems();
+                    assertEquals(1, items.length); // fails in 1.638
+                    assertEquals(p, items[0].task.getOwnerTask());
+                }
+                try (ACLContext context = ACL.as(User.getById("devel", true))) {
+                    Queue.Item[] items = Queue.getInstance().getItems();
+                    assertEquals(0, items.length); // fails in 1.609.2
+                }
                 // TODO this would be a good time to add a third user with READ but no CANCEL permission and check behavior
                 // Also try canceling the task and verify that the step aborts promptly:
                 Queue.Item[] items = Queue.getInstance().getItems();


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID."
- The documentation for [`ACL.impersonate(org.acegisecurity.Authentication, java.lang.Runnable)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#impersonate-org.acegisecurity.Authentication-java.lang.Runnable-) states: "use try with resources and [`as(Authentication)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#as-org.acegisecurity.Authentication-)".
- The documentation for [`Jenkins.getActiveInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getActiveInstance--) states: "This is a verbose historical alias for [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--)."
- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, I replaced any usages of `ACL.impersonate` with usages of try-with-resources and `ACL.as`, I replaced any calls to `Jenkins.getActiveInstance()` with calls to `Jenkins.get()`, and I replaced any calls to `Jenkins.getInstance()` with calls to `Jenkins.getInstanceOrNull()`.