### PR TITLE
Final line of shell output without newline lost when using LineTransformationOutputStream-based decorators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <revision>2.33</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
+        <jenkins-test-harness.version>2.54-rc1207.a9cdd7c1192a</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/149 -->
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
@@ -79,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.29</version>
+            <version>1.31-rc427.7bfff1482201</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/102 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
-            <version>1.16</version>
+            <version>1.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <revision>2.33</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.176.1</jenkins.version>
-        <jenkins-test-harness.version>2.54-rc1207.a9cdd7c1192a</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/149 -->
+        <jenkins-test-harness.version>2.54</jenkins-test-harness.version> <!-- TODO pending plugin-pom update -->
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.31-rc427.7bfff1482201</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/102 -->
+            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -584,7 +584,6 @@ public abstract class DurableTaskStep extends Step {
             byte[] produce() throws IOException, InterruptedException;
         }
         private void handleExit(int exitCode, OutputSupplier output) throws IOException, InterruptedException {
-            listener().getLogger().println(); // TODO
             Throwable originalCause = causeOfStoppage;
             if ((returnStatus && originalCause == null) || exitCode == 0) {
                 getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(output.produce(), StandardCharsets.UTF_8) : null);
@@ -600,6 +599,7 @@ public abstract class DurableTaskStep extends Step {
                     getContext().onFailure(new AbortException("script returned exit code " + exitCode));
                 }
             }
+            listener().getLogger().close();
         }
 
         // ditto
@@ -659,7 +659,6 @@ public abstract class DurableTaskStep extends Step {
                     synchronized (ps) { // like PrintStream.write overloads do
                         IOUtils.copy(stream, os);
                     }
-                    ps.println(); // TODO
                 } else {
                     // A subclass. Who knows why, but trust any write(…) overrides it may have.
                     IOUtils.copy(stream, ps);
@@ -680,7 +679,7 @@ public abstract class DurableTaskStep extends Step {
         }
 
         @Override public void exited(int code, byte[] output) throws Exception {
-            listener.getLogger().flush();
+            listener.getLogger().close();
             execution.exited(code, output);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -584,6 +584,7 @@ public abstract class DurableTaskStep extends Step {
             byte[] produce() throws IOException, InterruptedException;
         }
         private void handleExit(int exitCode, OutputSupplier output) throws IOException, InterruptedException {
+            listener().getLogger().println(); // TODO
             Throwable originalCause = causeOfStoppage;
             if ((returnStatus && originalCause == null) || exitCode == 0) {
                 getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(output.produce(), StandardCharsets.UTF_8) : null);
@@ -658,6 +659,7 @@ public abstract class DurableTaskStep extends Step {
                     synchronized (ps) { // like PrintStream.write overloads do
                         IOUtils.copy(stream, os);
                     }
+                    ps.println(); // TODO
                 } else {
                     // A subclass. Who knows why, but trust any write(…) overrides it may have.
                     IOUtils.copy(stream, ps);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -451,6 +451,12 @@ public abstract class DurableTaskStep extends Step {
                             super.write(b);
                             nl = b == '\n';
                         }
+                        @Override public void write(byte[] b, int off, int len) throws IOException {
+                            super.write(b, off, len);
+                            if (len > 0) {
+                                nl = b[off + len - 1] == '\n';
+                            }
+                        }
                         @Override public void close() throws IOException {
                             LOGGER.log(Level.FINE, "calling close with nl={0}", nl);
                             if (!nl) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -635,6 +635,9 @@ public class ShellStepTest {
                         errors.checkThat(log, containsString(mode + " final newline node=" + node + " watching=" + watching));
                     }
                 }
+                errors.checkThat("no blank lines with watching=" + watching, log, not(containsString("\n\n")));
+                errors.checkThat(log, not(containsString("watching=false[Pipeline]")));
+                errors.checkThat(log, not(containsString("watching=true[Pipeline]")));
             }
         } finally {
             DurableTaskStep.USE_WATCHING = origUseWatching;

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -17,9 +17,13 @@ import hudson.console.ConsoleLogFilter;
 import hudson.console.ConsoleNote;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.BallColor;
+import hudson.model.BooleanParameterDefinition;
+import hudson.model.BooleanParameterValue;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.remoting.Channel;
@@ -44,7 +48,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import javax.annotation.CheckForNull;
@@ -85,7 +88,6 @@ import static org.junit.Assert.*;
 import org.junit.Assume;
 import static org.junit.Assume.assumeFalse;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -601,7 +603,6 @@ public class ShellStepTest {
         j.assertLogContains("¡Čau → there!", j.buildAndAssertSuccess(p));
     }
 
-    @Ignore("TODO missing final line and in some cases even the `+ set +x` (but passes without withCredentials)")
     @Test public void missingNewline() throws Exception {
         assumeFalse(Functions.isWindows()); // TODO create Windows equivalent
         String credentialsId = "creds";
@@ -609,31 +610,32 @@ public class ShellStepTest {
         String password = "s3cr3t";
         UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c);
-        j.createSlave("remote", null, null);
+        DumbSlave s = j.createSlave("remote", null, null);
+        j.waitOnline(s);
+        logging.record(DurableTaskStep.class, Level.FINE).record(FileMonitoringTask.class, Level.FINE);
+        j.showAgentLogs(s, logging);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.addProperty(new ParametersDefinitionProperty(new BooleanParameterDefinition("WATCHING", false, null)));
         p.setDefinition(new CpsFlowDefinition(
-            "node('master') {\n" +
-            "  withCredentials([usernameColonPassword(variable: 'USERPASS', credentialsId: '" + credentialsId + "')]) {\n" +
-            "    sh 'set +x; printf \"some local output\"'\n" +
-            "  }\n" +
-            "}\n" +
-            "node('remote') {\n" +
-            "  withCredentials([usernameColonPassword(variable: 'USERPASS', credentialsId: '" + credentialsId + "')]) {\n" +
-            "    sh 'set +x; printf \"some remote output\"'\n" +
+            "['master', 'remote'].each {label ->\n" +
+            "  node(label) {\n" +
+            "    withCredentials([usernameColonPassword(variable: 'USERPASS', credentialsId: '" + credentialsId + "')]) {\n" +
+            "      sh 'set +x; echo \"with final newline node=$NODE_NAME watching=$WATCHING\"'\n" +
+            "      sh 'set +x; printf \"missing final newline node=$NODE_NAME watching=$WATCHING\"'\n" +
+            "    }\n" +
             "  }\n" +
             "}", true));
-        Callable<Void> test = () -> {
-            WorkflowRun b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-            j.assertLogContains("some local output", b);
-            j.assertLogContains("some remote output", b);
-            return null;
-        };
         boolean origUseWatching = DurableTaskStep.USE_WATCHING;
         try {
-            DurableTaskStep.USE_WATCHING = false;
-            errors.checkSucceeds(test);
-            DurableTaskStep.USE_WATCHING = true;
-            errors.checkSucceeds(test);
+            for (boolean watching : new boolean[] {false, true}) {
+                DurableTaskStep.USE_WATCHING = watching;
+                String log = JenkinsRule.getLog(j.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new BooleanParameterValue("WATCHING", watching)))));
+                for (String node : new String[] {"master", "remote"}) {
+                    for (String mode : new String[] {"with", "missing"}) {
+                        errors.checkThat(log, containsString(mode + " final newline node=" + node + " watching=" + watching));
+                    }
+                }
+            }
         } finally {
             DurableTaskStep.USE_WATCHING = origUseWatching;
         }


### PR DESCRIPTION
Fixing the test from #103, strengthening it in the process. Taking on some urgency since after @Vlatombe’s https://github.com/jenkinsci/kubernetes-plugin/pull/552, this problem would affect any `sh` step in a Kubernetes agent which prints output without a trailing newline (no longer limited to that minority of builds which deliberately use secrets).

- [X] tested fix
- [X] verification that `kubernetes` test workarounds can be removed: https://github.com/jenkinsci/kubernetes-plugin/pull/554
- [X] verification that partial lines are sanely handled in `pipeline-cloudwatch-logs`: https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/pull/58