### PR TITLE
[JENKINS-58900] Improve error messages for agent disconnections inside of node

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -26,10 +26,12 @@ package org.jenkinsci.plugins.workflow.support.steps;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.Computer;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.FilePathUtils;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.DynamicContext;
@@ -57,7 +59,14 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         if (f != null) {
             LOGGER.log(Level.FINE, "serving {0}:{1}", new Object[] {r.slave, r.path});
         } else {
-            LOGGER.log(Level.FINE, "failing to serve {0}:{1}", new Object[] {r.slave, r.path});
+            IOException e = new IOException("Unable to create live FilePath for " + r.slave);
+            Computer c = Jenkins.get().getComputer(r.slave);
+            if (c != null) {
+                for (Computer.TerminationRequest tr : c.getTerminatedBy()) {
+                    e.addSuppressed(tr);
+                }
+            }
+            throw e;
         }
         return f;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -27,6 +27,8 @@ package org.jenkinsci.plugins.workflow.support.steps;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
+import hudson.model.TaskListener;
+import hudson.slaves.OfflineCause;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.logging.Level;
@@ -64,6 +66,13 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
             if (c != null) {
                 for (Computer.TerminationRequest tr : c.getTerminatedBy()) {
                     e.addSuppressed(tr);
+                }
+            }
+            TaskListener listener = context.get(TaskListener.class);
+            if (listener != null) {
+                OfflineCause oc = c.getOfflineCause();
+                if (oc != null) {
+                    listener.getLogger().println(c.getDisplayName() + " was marked offline: " + oc);
                 }
             }
             throw e;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1168,9 +1168,10 @@ public class ExecutorStepTest {
             WorkflowJob p = r.createProject(WorkflowJob.class);
             p.setDefinition(new CpsFlowDefinition(
                     "node ('" + agent.getNodeName() + "') {\n" +
-                    "  sh('echo hello')\n" +
+                    "  def isUnix = isUnix()\n" + // Only call `isUnix()` before the agent goes offline to avoid additional log warnings.
+                    "  isUnix ? sh('echo hello') : bat('echo hello')\n" +
                     "  semaphore('wait')\n" +
-                    "  sh('echo world')\n" +
+                    "  isUnix ? sh('echo world') : bat('echo hello')\n" +
                     "}", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1171,7 +1171,7 @@ public class ExecutorStepTest {
                     "  def isUnix = isUnix()\n" + // Only call `isUnix()` before the agent goes offline to avoid additional log warnings.
                     "  isUnix ? sh('echo hello') : bat('echo hello')\n" +
                     "  semaphore('wait')\n" +
-                    "  isUnix ? sh('echo world') : bat('echo hello')\n" +
+                    "  isUnix ? sh('echo world') : bat('echo world')\n" +
                     "}", true));
             WorkflowRun b = p.scheduleBuild2(0).waitForStart();
             SemaphoreStep.waitForStart("wait/1", b);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1184,7 +1184,7 @@ public class ExecutorStepTest {
             r.assertBuildStatus(Result.FAILURE, b);
             r.assertLogContains("hello", b);
             r.assertLogNotContains("world", b);
-            r.assertLogContains("MissingContextVariableException: Required context class hudson.FilePath is missing", b);
+            r.assertLogContains("IOException: Unable to create live FilePath for " + agent.getNodeName(), b);
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1184,6 +1184,7 @@ public class ExecutorStepTest {
             r.assertBuildStatus(Result.FAILURE, b);
             r.assertLogContains("hello", b);
             r.assertLogNotContains("world", b);
+            r.assertLogContains("going offline", b);
             r.assertLogContains("IOException: Unable to create live FilePath for " + agent.getNodeName(), b);
         });
     }


### PR DESCRIPTION
See [JENKINS-58900](https://issues.jenkins-ci.org/browse/JENKINS-58900).

The problem is that you get a `MissingContextVariableException` where you would expect to get some kind of connection-related exception (seen on some builds of Jenkins core on ci.jenkins.io where the Windows agent apparently disconnected but the error in the logs was a `MissingContextVariableException`). I think this is a side effect of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/101 ([JENKINS-41854](https://issues.jenkins-ci.org/browse/JENKINS-41854)), but I haven't investigated enough to know for sure. If so, maybe fixable by throwing some kind of exception instead of just logging here: https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/5840b563c6c0cd9b7f721bcaff55e4b005be234d/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java#L60

CC @oleg-nenashev 