### PR TITLE
Use ACI agents to avoid disk space issues in CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
+buildPlugin(useAci: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
     [platform: 'linux', jdk: '11'],


### PR DESCRIPTION
Trying to fix CI issues (for example in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/115). It doesn't look like this plugin's tests use Docker, but they might be sensitive to user/permission changes in the ACI agents, so we'll see if the build passes.