### PR TITLE
Release node body reference when finishing a PlaceholderTask

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -277,12 +277,13 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         } catch (Exception x) {
                             LOGGER.log(Level.WARNING, null, x);
                         }
-                        if (task.body == null) {
+                        BodyExecution body = task.body != null ? task.body.get() : null;
+                        if (body == null) {
                             listener.getLogger().println("Agent " + node.getNodeName() + " was deleted, but do not have a node body to cancel");
                             continue;
                         }
                         listener.getLogger().println("Agent " + node.getNodeName() + " was deleted; cancelling node body");
-                        task.body.get().cancel(new RemovedNodeCause());
+                        body.cancel(new RemovedNodeCause());
                     }
                 }
             }, ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -837,7 +837,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
                         }
                         listener.getLogger().println("Running on " + ModelHyperlinkNote.encodeTo(node) + " in " + workspace);
-                        body = new WeakReference<BodyExecution>(context.newBodyInvoker()
+                        body = new WeakReference<>(context.newBodyInvoker()
                                 .withContexts(exec, computer, env,
                                     FilePathDynamicContext.createContextualObject(workspace))
                                 .withCallback(new Callback(cookie, lease))

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -34,6 +34,7 @@ import hudson.slaves.WorkspaceList;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -281,7 +282,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             continue;
                         }
                         listener.getLogger().println("Agent " + node.getNodeName() + " was deleted; cancelling node body");
-                        task.body.cancel(new RemovedNodeCause());
+                        task.body.get().cancel(new RemovedNodeCause());
                     }
                 }
             }, ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);
@@ -335,7 +336,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
          * So we make a best effort and only try to cancel a body within the current session.
          * @see RemovedNodeListener
          */
-        private transient @CheckForNull BodyExecution body;
+        private transient @CheckForNull WeakReference<BodyExecution> body;
 
         /** {@link Authentication#getName} of user of build, if known. */
         private final @CheckForNull String auth;
@@ -725,16 +726,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     // JENKINS-30759: finished before asynch execution was even scheduled
                     return;
                 }
-                final Executor executor = execution.getExecutor();
-                if (executor != null) {
-                    final Queue.Executable exec = executor.getCurrentExecutable();
-                    if (exec instanceof PlaceholderTask.PlaceholderExecutable) {
-                        final PlaceholderExecutable placeholderExec = (PlaceholderExecutable) exec;
-                        if (placeholderExec.getParent().body != null) {
-                            placeholderExec.getParent().body = null;
-                        }
-                    }
-                }
                 assert runningTask.launcher != null;
                 Timer.get().submit(new Runnable() { // JENKINS-31614
                     @Override public void run() {
@@ -845,11 +836,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
                         }
                         listener.getLogger().println("Running on " + ModelHyperlinkNote.encodeTo(node) + " in " + workspace);
-                        body = context.newBodyInvoker()
+                        body = new WeakReference<BodyExecution>(context.newBodyInvoker()
                                 .withContexts(exec, computer, env,
                                     FilePathDynamicContext.createContextualObject(workspace))
                                 .withCallback(new Callback(cookie, lease))
-                                .start();
+                                .start());
                         LOGGER.log(FINE, "started {0}", cookie);
                     } else {
                         // just rescheduled after a restart; wait for task to complete

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -725,6 +725,16 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     // JENKINS-30759: finished before asynch execution was even scheduled
                     return;
                 }
+                final Executor executor = execution.getExecutor();
+                if (executor != null) {
+                    final Queue.Executable exec = executor.getCurrentExecutable();
+                    if (exec instanceof PlaceholderTask.PlaceholderExecutable) {
+                        final PlaceholderExecutable placeholderExec = (PlaceholderExecutable) exec;
+                        if (placeholderExec.getParent().body != null) {
+                            placeholderExec.getParent().body = null;
+                        }
+                    }
+                }
                 assert runningTask.launcher != null;
                 Timer.get().submit(new Runnable() { // JENKINS-31614
                     @Override public void run() {


### PR DESCRIPTION
### Problem

After upgrading `workflow-durable-task-step` from 2.31 to 2.32 in `workflow-cps-global-lib-plugin`, `LibraryMemoryTest#loaderReleased` starts failing with the following stack trace:

```
[ERROR] loaderReleased(org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest)  Time elapsed: 1.561 s  <<< ERROR!
java.lang.NullPointerException
	at org.netbeans.insane.live.Path.getField(Path.java:146)
	at org.netbeans.insane.live.Path.toString(Path.java:140)
	at org.netbeans.insane.live.Path.toString(Path.java:138)
	at java.lang.String.valueOf(String.java:2994)
	at java.lang.StringBuilder.append(StringBuilder.java:131)
	at java.util.AbstractMap.toString(AbstractMap.java:559)
	at java.lang.String.valueOf(String.java:2994)
	at java.lang.StringBuilder.append(StringBuilder.java:131)
	at org.jvnet.hudson.test.MemoryAssert.assertGC(MemoryAssert.java:187)
	at org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.loaderReleased(LibraryMemoryTest.java:85)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:599)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

### Evaluation

Bisection revealed that the problem does not occur with `workflow-durable-task-step` 2.31 (see jenkinsci/workflow-cps-global-lib-plugin#80) but does occur with `workflow-durable-task-step` 2.32 (see jenkinsci/workflow-cps-global-lib-plugin#81). Looking at the changes [in the compare view](https://github.com/jenkinsci/workflow-durable-task-step-plugin/compare/workflow-durable-task-step-2.31...workflow-durable-task-step-2.32), I noticed two new fields: `DurableTaskStep#removedNodeDiscovered` and `PlaceholderTask#body`, both added in jenkinsci/workflow-durable-task-step-plugin#104. `DurableTaskStep#removedNodeDiscovered` is a `long` and is unlikely to be the leak, so I hypothesized that `PlaceholderTask#body` was the leak. Sure enough, when I changed `body = context.newBodyInvoker().[...]` back to `context.newBodyInvoker().[...]` in `PlaceholderExecutable#run` (the only place where `PlaceholderExecutable#body` was ever set) and re-ran `LibraryMemoryTest#loaderReleased`, it passed. This confirmed that the proximate source of the problem was `PlaceholderTask#body`.

While I don't know enough about this plugin to be completely sure, based on the above analysis I strongly suspect that the cause of the problem is that `PlaceholderTask#body` is being leaked, exposing the `workflow-cps-global-lib-plugin` test failure in `LibraryMemoryTest#loaderReleased`.

### Solution

Assuming that the above evaluation is correct, the solution would be to release `PlaceholderExecutable#body` when it is no longer needed. Without knowing very much about this plugin, `PlaceholderTask#finish` seemed like as good a place as any to do this. Much to my surprise, `workflow-cps-global-lib-plugin`'s `LibraryMemoryTest#loaderReleased` test started passing again once I made this change.

If I am misunderstanding the cause of the problem or if there is a better solution, please feel free to let me know.