### PR TITLE
Prevent lease leak when ws or node is called with no body

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -101,6 +101,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
      */
     @Override
     public boolean start() throws Exception {
+        if(!getContext().hasBody()) {
+            throw new AbortException("The node step must be called with a body");
+        }
         final PlaceholderTask task = new PlaceholderTask(getContext(), step.getLabel());
         Queue.WaitingItem waitingItem = Queue.getInstance().schedule2(task, 0).getCreateItem();
         if (waitingItem == null) {
@@ -793,9 +796,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     Executor exec = Executor.currentExecutor();
                     if (exec == null) {
                         throw new IllegalStateException("running task without associated executor thread");
-                    }
-                    if (!context.hasBody()) {
-                        throw new Exception("node must be called with a body");
                     }
                     computer = exec.getOwner();
                     // Set up context for other steps inside this one.

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -794,6 +794,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     if (exec == null) {
                         throw new IllegalStateException("running task without associated executor thread");
                     }
+                    if (!context.hasBody()) {
+                        throw new Exception("node must be called with a body");
+                    }
                     computer = exec.getOwner();
                     // Set up context for other steps inside this one.
                     Node node = computer.getNode();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -3,6 +3,8 @@ package org.jenkinsci.plugins.workflow.support.steps;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+
+import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -36,7 +38,7 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
             throw new Exception(job + " must be a top-level job");
         }
         if (!getContext().hasBody()) {
-            throw new Exception("ws must be called with a body");
+            throw new AbortException("The ws step must be called with a body");
         }
         Computer computer = getContext().get(Computer.class);
         Node node = computer.getNode();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -35,6 +35,9 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
         if (!(job instanceof TopLevelItem)) {
             throw new Exception(job + " must be a top-level job");
         }
+        if (!getContext().hasBody()) {
+            throw new Exception("ws must be called with a body");
+        }
         Computer computer = getContext().get(Computer.class);
         Node node = computer.getNode();
         if (node == null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1214,7 +1214,7 @@ public class ExecutorStepTest {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("node('')", true));
             WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
-            r.assertLogContains("node must be called with a body", b);
+            r.assertLogContains("The node step must be called with a body", b);
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1208,6 +1208,16 @@ public class ExecutorStepTest {
         });
     }
 
+    @Test
+    public void nodeNoBody() throws Exception {
+        story.then( r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node('')", true));
+            WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
+            r.assertLogContains("node must be called with a body", b);
+        });
+    }
+
     private static class MainAuthenticator extends QueueItemAuthenticator {
         @Override public Authentication authenticate(Queue.Task task) {
             return task instanceof WorkflowJob ? User.getById("dev", true).impersonate() : null;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepTest.java
@@ -88,7 +88,7 @@ public class WorkspaceStepTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {ws('test')}", true));
         WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
-        r.assertLogContains("ws must be called with a body", b);
+        r.assertLogContains("The ws step must be called with a body", b);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.support.steps;
 
+import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.WorkspaceList;
 import java.io.File;
@@ -80,6 +81,14 @@ public class WorkspaceStepTest {
         r.buildAndAssertSuccess(p);
         assertFalse(WorkspaceList.tempDir(r.jenkins.getWorkspaceFor(p)).child("x").exists());
         assertTrue(WorkspaceList.tempDir(r.jenkins.getWorkspaceFor(p).sibling("p@2")).child("x").exists());
+    }
+
+    @Test
+    public void wsNoBody() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {ws('test')}", true));
+        WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
+        r.assertLogContains("ws must be called with a body", b);
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Currently calling the ws step with no body will leak a lease of the workspace requested for in that step, as the step will fail due to not having a body for bodyinvoker. Check that there is a body and if no body is supplied fail early.

```
node {
    ws('/some/path') // /some/path leaks and subsequent runs will not be able to use it without @2 being appended
}
```