### PR TITLE
[JENKINS-62014] Add support for build step environment filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.36</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.236-SNAPSHOT</jenkins.version>
+        <jenkins.version>2.248</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.35-SNAPSHOT</version>
+            <version>1.35-rc463.dbcd6297773f</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.1</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.36</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.1</jenkins.version>
+        <jenkins.version>2.236-SNAPSHOT</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.33</version>
+            <version>1.35-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -35,6 +35,7 @@ import hudson.Util;
 import hudson.init.Terminator;
 import hudson.model.Node;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelClosedException;
@@ -302,6 +303,7 @@ public abstract class DurableTaskStep extends Step {
             ws = context.get(FilePath.class);
             node = FilePathUtils.getNodeName(ws);
             DurableTask durableTask = step.task();
+            durableTask.setRun(context.get(Run.class));
             if (returnStdout) {
                 durableTask.captureOutput();
             }


### PR DESCRIPTION
See [JENKINS-62014](https://issues.jenkins-ci.org/browse/JENKINS-62014).

This adds support for global build step environment filters to durable task based pipeline steps.

Downstream from https://github.com/jenkinsci/jenkins/pull/4683 and https://github.com/jenkinsci/durable-task-plugin/pull/124.