### PR TITLE
[JENKINS-62014] Add support for global build step env var filters

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Duse-jenkins-bom

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Duse-jenkins-bom

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 buildPlugin(useAci: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
-    [platform: 'linux', jdk: '11'],
-    [platform: 'windows', jdk: '11']
+    [platform: 'linux', jdk: '11']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -162,5 +162,11 @@
             <version>1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.29</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>generic-environment-filters</artifactId>
-            <version>1.1</version>
+            <version>1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.4</version>
+        <version>4.6</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.33</version>
+            <version>2.40</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,46 +67,48 @@
         <jenkins.version>2.248</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
-        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
-        <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>11</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.33</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.40</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.70</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.31</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,54 +120,41 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials-binding</artifactId>
-            <version>1.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.71</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.2.6</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>generic-environment-filters</artifactId>
             <version>1.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.29</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.54</version>
+        <version>4.4</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.36</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.1</jenkins.version>
+        <jenkins.version>2.248</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,5 +156,11 @@
             <artifactId>scm-api</artifactId>
             <version>2.2.6</version>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>generic-environment-filters</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jenkins.version>2.248</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
-        <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.22</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
     </properties>
     <dependencies>
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.58</version>
+            <version>1.71</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -35,6 +35,7 @@ import hudson.Util;
 import hudson.init.Terminator;
 import hudson.model.Node;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelClosedException;
@@ -61,6 +62,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import jenkins.tasks.filters.EnvVarsFilterableBuilder;
 import jenkins.util.Timer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -96,7 +98,7 @@ import org.kohsuke.stapler.QueryParameter;
  * When the process exits, the status code is also written to a file and ultimately results in the step passing or failing.
  * <p>Tasks can also be run on the master node, which differs only in that there is no possibility of a network failure.
  */
-public abstract class DurableTaskStep extends Step {
+public abstract class DurableTaskStep extends Step implements EnvVarsFilterableBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(DurableTaskStep.class.getName());
 
@@ -312,6 +314,7 @@ public abstract class DurableTaskStep extends Step {
                 durableTask.defaultCharset();
             }
             Launcher launcher = context.get(Launcher.class);
+            launcher.prepareFilterRules(context.get(Run.class), step);
             LOGGER.log(Level.FINE, "launching task against {0} using {1}", new Object[] {ws.getChannel(), launcher});
             try {
                 controller = durableTask.launch(context.get(EnvVars.class), ws, launcher, listener);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -836,8 +836,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         FilePath workspace = lease.path;
                         // Cf. AbstractBuild.getEnvironment:
                         env.put("WORKSPACE", workspace.getRemote());
-                        if (workspace.getParent() != null) {
-                            env.put("WORKSPACE_TMP", WorkspaceList.tempDir(workspace).getRemote()); // JENKINS-60634
+                        final FilePath tempDir = WorkspaceList.tempDir(workspace);
+                        if (tempDir != null) {
+                            env.put("WORKSPACE_TMP", tempDir.getRemote()); // JENKINS-60634
                         }
                         FlowNode flowNode = context.get(FlowNode.class);
                         if (flowNode != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -62,8 +62,9 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
         getContext().get(TaskListener.class).getLogger().println("Running in " + workspace);
         Map<String, String> env = new HashMap<>();
         env.put("WORKSPACE", workspace.getRemote());
-        if (workspace.getParent() != null) {
-            env.put("WORKSPACE_TMP", WorkspaceList.tempDir(workspace).getRemote());
+        final FilePath tempDir = WorkspaceList.tempDir(workspace);
+        if (tempDir != null) {
+            env.put("WORKSPACE_TMP", tempDir.getRemote());
         }
         getContext().newBodyInvoker()
                 .withContexts(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -19,6 +19,7 @@ import hudson.model.BallColor;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.BooleanParameterValue;
 import hudson.model.BuildListener;
+import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.model.ParametersAction;
@@ -32,6 +33,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
+import io.jenkins.plugins.environment_filter_utils.util.BuilderUtil;
 import io.jenkins.plugins.generic_environment_filters.RemoveSpecificVariablesFilter;
 import io.jenkins.plugins.generic_environment_filters.VariableContributingFilter;
 import java.io.ByteArrayOutputStream;
@@ -61,6 +63,8 @@ import jenkins.util.JenkinsJVM;
 import org.apache.commons.lang.StringUtils;
 
 import static org.hamcrest.Matchers.*;
+
+import org.hamcrest.MatcherAssert;
 import org.jenkinsci.plugins.durabletask.FileMonitoringTask;
 
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
@@ -742,6 +746,15 @@ public class ShellStepTest {
         j.assertLogContains("FOO=", b);
         j.assertLogNotContains("FOO=BAR", b);
         j.assertLogContains("BAZ=QUX", b);
+    }
+
+    @Issue("JENKINS-62014")
+    @Test public void ensureTypes() throws Exception {
+        final List<Descriptor> descriptors = BuilderUtil.allDescriptors();
+
+        MatcherAssert.assertThat(descriptors , containsInAnyOrder(
+                j.jenkins.getDescriptor(Shell.class), j.jenkins.getDescriptor(BatchFile.class),
+                j.jenkins.getDescriptor(BatchScriptStep.class), j.jenkins.getDescriptor(PowershellScriptStep.class), j.jenkins.getDescriptor(ShellStep.class), j.jenkins.getDescriptor(PowerShellCoreScriptStep.class)));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -739,7 +739,11 @@ public class ShellStepTest {
         p.setDefinition(new CpsFlowDefinition(
                 "node() {\n" +
                 "  withEnv(['FOO=BAR']) {\n" +
-                "    sh('echo FOO=$FOO and BAZ=$BAZ')\n" +
+                "    if (isUnix()) {\n" +
+                "      sh('echo FOO=$FOO and BAZ=$BAZ')\n" +
+                "    } else {\n" +
+                "      bat('ECHO FOO=%FOO% and BAZ=%BAZ%')\n" +
+                "    }\n" +
                 "  }\n" +
                 "}", true));
         WorkflowRun b = j.buildAndAssertSuccess(p);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -729,7 +729,7 @@ public class ShellStepTest {
 
     @Issue("JENKINS-62014")
     @Test public void envVarFilters() throws Exception {
-        EnvVarsFilterGlobalConfiguration.getAllActivatedGlobalRules().add(new RemoveSpecificVariablesFilter("FOO", "TODO: UNUSED"));
+        EnvVarsFilterGlobalConfiguration.getAllActivatedGlobalRules().add(new RemoveSpecificVariablesFilter("FOO"));
         EnvVarsFilterGlobalConfiguration.getAllActivatedGlobalRules().add(new VariableContributingFilter("BAZ", "QUX"));
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition(

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -199,6 +199,10 @@ public class ShellStepTest {
 
         b.getExecutor().interrupt();
 
+        // It can take a while for the process to exit on Windows (see JENKINS-59152), so we wait for the build to
+        // complete and confirm that the process is no longer running after the build has already completed.
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
+
         // touching should have stopped
         final long refTimestamp = Files.getLastModifiedTime(tmp).toMillis();
         ensureForWhile(5000, tmp, tmpFile -> {
@@ -208,8 +212,6 @@ public class ShellStepTest {
                 throw new UncheckedIOException(e);
             }
         });
-
-        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
     }
 
     @Issue("JENKINS-41339")

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -339,13 +339,14 @@ public class ExecutorStepTest {
                 new FileOutputStream(f1).close();
                 p.setDefinition(new CpsFlowDefinition(
                     "node('dumbo') {\n" +
-                    "    sh 'touch \"" + f2 + "\"; while [ -f \"" + f1 + "\" ]; do sleep 1; done; echo finished waiting; rm \"" + f2 + "\"'\n" +
+                    "    sh 'touch \"" + f2 + "\"; while [ -f \"" + f1 + "\" ]; do echo waiting; sleep 1; done; echo finished waiting; rm \"" + f2 + "\"'\n" +
                     "    echo 'OK, done'\n" +
                     "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 while (!f2.isFile()) {
                     Thread.sleep(100);
                 }
+                story.j.waitForMessage("waiting", b);
                 assertTrue(b.isBuilding());
                 Computer c = s.toComputer();
                 assertNotNull(c);
@@ -392,7 +393,7 @@ public class ExecutorStepTest {
                 new FileOutputStream(f1).close();
                 p.setDefinition(new CpsFlowDefinition(
                         "node('dumbo') {\n" +
-                                "    sh 'touch \"" + f2 + "\"; while [ -f \"" + f1 + "\" ]; do sleep 1; done; echo finished waiting; rm \"" + f2 + "\"'\n" +
+                                "    sh 'touch \"" + f2 + "\"; while [ -f \"" + f1 + "\" ]; do echo waiting; sleep 1; done; echo finished waiting; rm \"" + f2 + "\"'\n" +
                                 "    sh 'echo Back again'\n" +
                                 "    echo 'OK, done'\n" +
                                 "}", true));
@@ -401,6 +402,7 @@ public class ExecutorStepTest {
                 while (!f2.isFile()) {
                     Thread.sleep(100);
                 }
+                story.j.waitForMessage("waiting", b);
                 LOGGER.info("f2 created, first sh running");
                 assertTrue(b.isBuilding());
                 Computer computer = s.toComputer();


### PR DESCRIPTION
After feedback from @dwnusbaum in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/135#discussion_r459644019, this is now a much simpler implementation.

### Testing notes

Install https://plugins.jenkins.io/generic-environment-filters/ 1.1 or newer, and configure any of the global filters it provides in the global configuration.

* The easiest to test is "Set environment variable" as it just adds a new environment variable.
* The most comprehensive test case is "Filter environment variables..." as that allows the definition of job name exclusions, and can be configured to only apply to certain build steps. Both features work with this PR, although the latter is a bit messy because freestyle and pipeline steps have similar names, and show up in the same list here. That's just a https://plugins.jenkins.io/environment-filter-utils/ issue though that shouldn't matter here.