### PR TITLE
[JENKINS-63486] Use ACL.SYSTEM in PlaceholderTask.getOwnerTask as before JENKINS-60389

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -431,9 +431,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         @Override public Queue.Task getOwnerTask() {
             Jenkins j = Jenkins.getInstanceOrNull();
             if (j != null && runId != null) { // JENKINS-60389 shortcut
-                Job<?, ?> job = j.getItemByFullName(runId.substring(0, runId.lastIndexOf('#')), Job.class);
-                if (job instanceof Queue.Task) {
-                    return (Queue.Task) job;
+                try (ACLContext context = ACL.as(ACL.SYSTEM)) {
+                    Job<?, ?> job = j.getItemByFullName(runId.substring(0, runId.lastIndexOf('#')), Job.class);
+                    if (job instanceof Queue.Task) {
+                        return (Queue.Task) job;
+                    }
                 }
             }
             Run<?,?> r = runForDisplay();


### PR DESCRIPTION
See [JENKINS-63486](https://issues.jenkins.io/browse/JENKINS-63486). Amends #126.

[JENKINS-63868](https://issues.jenkins.io/browse/JENKINS-63868) was fixed in recent versions of Jenkins core, but it will still log a warning every time this code throws an exception, so we should change this code anyway.

I added a regression test in 2c1da66, but I have not attempted to reproduce the problem or test the fix on a real Jenkins instance.