### PR TITLE
failing ExecutorStepTest in jenkins versions > 2.65

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: true, configurations: [
-    [platform: 'linux', jdk: '8'],
-    [platform: 'windows', jdk: '8'],
-    [platform: 'linux', jdk: '11']
+    [platform: 'linux', jdk: '8', jenkins: null],
+    [platform: 'windows', jdk: '8', jenkins: null],
+    [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: true, configurations: [
-    [platform: 'linux', jdk: '8', jenkins: null],
-    [platform: 'windows', jdk: '8', jenkins: null],
+    [platform: 'linux', jdk: '8'],
+    [platform: 'windows', jdk: '8'],
     [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]
 ])

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -73,6 +73,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
+import hudson.util.VersionNumber;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
@@ -864,7 +865,8 @@ public class ExecutorStepTest {
         story.then(r -> {
             // Note: for Jenkins versions > 2.65, the number of agents must be increased to 5.
             // This is due to changes in the Load Balancer (See JENKINS-60563).
-            for (int i = 0; i < 3; ++i) {
+            int totalAgents = Jenkins.getVersion().isNewerThan(new VersionNumber("2.265")) ? 5 : 3;
+            for (int i = 0; i < totalAgents; ++i) {
                 DumbSlave slave = r.createOnlineSlave();
                 slave.setLabelString("foo bar");
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -862,6 +862,8 @@ public class ExecutorStepTest {
     @Issue("JENKINS-36547")
     @Test public void reuseNodesWithSameLabelsInDifferentReorderedStages() {
         story.then(r -> {
+            // Note: for Jenkins versions > 2.65, the number of agents must be increased to 5.
+            // This is due to changes in the Load Balancer (See JENKINS-60563).
             for (int i = 0; i < 3; ++i) {
                 DumbSlave slave = r.createOnlineSlave();
                 slave.setLabelString("foo bar");


### PR DESCRIPTION
When running Jenkins versions > 2.65, the `ExecutorStepTest.reuseNodesWithSameLabelsInDifferentReorderedStages` test will fail.

This is due to changes in `LoadBalancer`  that were done in 2.66 here: https://github.com/jenkinsci/jenkins/pull/5028

Added a note to indicate this in the test code.