### PR TITLE
Add support to enable/disable PowerShell profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
+            <version>1.36-rc473.404fedc2031a</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowershellScriptStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowershellScriptStep.java
@@ -28,6 +28,7 @@ import hudson.Extension;
 import org.jenkinsci.plugins.durabletask.DurableTask;
 import org.jenkinsci.plugins.durabletask.PowershellScript;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Asynchronous batch script execution.
@@ -35,6 +36,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class PowershellScriptStep extends DurableTaskStep {
 
     private final String script;
+    public boolean loadProfile;
 
     @DataBoundConstructor public PowershellScriptStep(String script) {
         if (script == null) {
@@ -47,8 +49,19 @@ public class PowershellScriptStep extends DurableTaskStep {
         return script;
     }
 
+    public boolean isLoadProfile() {
+        return loadProfile;
+    }
+
+    @DataBoundSetter
+    public void setLoadProfile(boolean loadProfile) {
+        this.loadProfile = loadProfile;
+    }
+
     @Override protected DurableTask task() {
-        return new PowershellScript(script);
+        PowershellScript ps = new PowershellScript(script);
+        ps.setLoadProfile(loadProfile);
+        return ps;
     }
 
     @Extension public static final class DescriptorImpl extends DurableTaskStepDescriptor {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/PowershellScriptStep/config-details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/steps/durable_task/PowershellScriptStep/config-details.jelly
@@ -27,4 +27,8 @@ THE SOFTWARE.
     <f:entry field="script" title="PowerShell Script">
         <f:textarea/>
     </f:entry>
+    <f:entry field="loadProfile" title="Load Profile">
+        <f:checkbox />
+    </f:entry>
+
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowerShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/PowerShellStepTest.java
@@ -73,5 +73,21 @@ public class PowerShellStepTest {
         Assume.assumeTrue("Correct UTF-8 output should be produced",log.contains("Hëllö Wórld"));
     }
 
+    @Test public void testNoProfile() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "baz");
+        p.setDefinition(new CpsFlowDefinition("node { powershell(script: 'if ((Get-CimInstance Win32_Process -Filter \"ProcessId = $PID\").CommandLine.split(\" \").Contains(\"-NoProfile\")) { exit 0; } else { exit 1; } ')}", true));
+        WorkflowRun b = p.scheduleBuild2(0).get();
+        Result r = b.getResult();
+        Assume.assumeTrue("The plugin defaults to run Powershell with the -NoProfile option", r == Result.SUCCESS);
+    }
+
+    @Test public void testWithProfile() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "bazooka");
+        p.setDefinition(new CpsFlowDefinition("node { powershell(loadProfile: true, script: 'if ((Get-CimInstance Win32_Process -Filter \"ProcessId = $PID\").CommandLine.split(\" \").Contains(\"-NoProfile\")) { exit 0; } else { exit 1; } ')}", true));
+        WorkflowRun b = p.scheduleBuild2(0).get();
+        Result r = b.getResult();
+        Assume.assumeTrue("The plugin defaults to run Powershell with the -NoProfile option", r == Result.FAILURE);
+    }
+
 }
 


### PR DESCRIPTION
Hey,
I implemented an option to enable or disable loading of the PowerShell profile. This change doesn't affect the default behavior of the plugin (disable loading of profile). The test demonstrate how this can be used. Since it's hard to write a unit test for this, I relied on creating a PS script that would check if the NoProfile option was present in the current process. The changes to support this behavior are already merged upstream. I bumped the version in the pom for testing purposes, feel free to drop that commit.

Here's my checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Here's the relevant upstream PR:
https://github.com/jenkinsci/durable-task-plugin/pull/130

Cheers, Mark