### PR TITLE
Change NODE_NAME for the built-in node based on its self label

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -809,7 +809,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         env.put(COOKIE_VAR, cookie);
                         // Cf. CoreEnvironmentContributor:
                         if (exec.getOwner() instanceof MasterComputer) {
-                            env.put("NODE_NAME", "master");
+                            env.put("NODE_NAME", node.getSelfLabel().getName()); // mirror https://github.com/jenkinsci/jenkins/blob/89d334145d2755f74f82aad07b5df4119d7fa6ce/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java#L63
                         } else {
                             env.put("NODE_NAME", label);
                         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -47,13 +47,14 @@ public class EnvWorkflowTest {
     @Test public void isNodeNameAvailable() throws Exception {
         r.createSlave("node-test", "unix fast", null);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "workflow-test");
+        final String builtInNodeName = r.jenkins.getSelfLabel().getName();
 
         p.setDefinition(new CpsFlowDefinition(
             "node('master') {\n" +
             "  echo \"My name on master is ${env.NODE_NAME} using labels ${env.NODE_LABELS}\"\n" +
             "}\n",
             true));
-        r.assertLogContains("My name on master is master using labels master", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+        r.assertLogContains("My name on master is " + builtInNodeName + " using labels master", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
 
         p.setDefinition(new CpsFlowDefinition(
             "node('node-test') {\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/EnvWorkflowTest.java
@@ -55,7 +55,7 @@ public class EnvWorkflowTest {
             "  echo \"My name on master is ${env.NODE_NAME} using labels ${env.NODE_LABELS}\"\n" +
             "}\n",
             true));
-        r.assertLogContains("My name on master is " + builtInNodeName + " using labels master", r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+        r.assertLogContains("My name on master is " + builtInNodeName + " using labels " + builtInNodeLabel, r.assertBuildStatusSuccess(p.scheduleBuild2(0)));
 
         p.setDefinition(new CpsFlowDefinition(
             "node('node-test') {\n" +


### PR DESCRIPTION
This implements the same terminology cleanup as https://github.com/jenkinsci/jenkins/pull/5425 did in core for for `NODE_NAME` variable which is set here independently of core.

This is independent of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/167 but without that PR, this one will timeout on 2.307+ (unchanged from before).

This is not expected to result in a behavior difference on Jenkins 2.306 and earlier.

On Jenkins 2.307 and later, this PR will change the behavior and make it consistent with core's (freestyle jobs etc.). This can easily be tested by using the script console to provide a custom name and label for the built-in node:

```
Jenkins.nodeNameAndSelfLabelOverride = 'mast-in'
```

----

Changelog suggestion:

* The `NODE_NAME` environment variable value set for the built-in node inside `node` blocks now matches the behavior of other job types: On Jenkins 2.306 and earlier, the behavior is unchanged (`master`). On Jenkins 2.307 and later, the variable will be `built-in` or `master`, depending on whether the instance was upgraded from a previous release or newly installed, and whether the migration was applied. See https://www.jenkins.io/redirect/built-in-node-migration/