### PR TITLE
Implement `Queue.Executable.getParentExecutable`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -913,6 +913,16 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return PlaceholderTask.this;
             }
 
+            // TODO https://github.com/jenkinsci/jenkins/pull/5733 @Override
+            public Queue.Executable getParentExecutable() {
+                Run<?, ?> b = runForDisplay();
+                if (b instanceof Queue.Executable) {
+                    return (Queue.Executable) b;
+                } else {
+                    return null;
+                }
+            }
+
             @Exported
             public Integer getNumber() {
                 Run<?, ?> r = getParent().runForDisplay();


### PR DESCRIPTION
Pairs with https://github.com/jenkinsci/jenkins/pull/5733; for now I am not bothering to increase the `jenkins.version`.
