### PR TITLE
Revert "Remove deprecated config (#172)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useAci: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
     [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]


### PR DESCRIPTION
This reverts commit fee3af9f1c5a9c0519e80e64750d0d2f76a1223e.

<!-- Please describe your pull request here. -->
`ExecutorPickleTest.canceledQueueItem` has been consistently failing on the windows CI instances since the change from `useAci` to `useContainerAgent`. Local builds on my windows machine have been passing. Reverting this commit to see if this was the issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
