### PR TITLE
chore: revert back to 'useContainerAgent' for CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useAci: true, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
     [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]


### PR DESCRIPTION
This PR is a tentative to study the behavior underlined in #173 / #172 (changing a pipeline library parameter that made a test unit to fail)