### PR TITLE
Nicer build log message when `ExecutorPickle` fails to resume

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -129,7 +129,7 @@ public class ExecutorPickle extends Pickle {
                             if (System.nanoTime() > endTimeNanos) {
                                 Queue.getInstance().cancel(item);
                                     throw new AbortException(MessageFormat.format("Killed {0} after waiting for {1} ms because we assume unknown Node {2} is never going to appear!",
-                                            item, TIMEOUT_WAITING_FOR_NODE_MILLIS, placeholder.getAssignedLabel().toString()));
+                                            item.task.getDisplayName(), TIMEOUT_WAITING_FOR_NODE_MILLIS, placeholder.getAssignedLabel().toString()));
                             }
                         }
                     }


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/47#discussion_r134517658

In https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/65a4f98c89953d9655a02d0de591af24bf300715/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java#L141-L144

Before:

```
[p #1] ERROR: Killed hudson.model.Queue$BuildableItem:ExecutorStepExecution.PlaceholderTask{runId=p#1,label=slave0,context=CpsStepContext[3:node]:Owner[p/1:p #1],cookie=1f900f85-0501-4f30-83d9-4a8a9ed1f70a,auth=null}:3 after waiting for 15,000 ms because we assume unknown Node slave0 is never going to appear!
```

After:

```
[p #1] ERROR: Killed part of p #1 after waiting for 15,000 ms because we assume unknown Node slave0 is never going to appear!
```
