### PR TITLE
Make `ExecutorPickle` add `RemovedNodeCause`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
-    [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]
+    [platform: 'linux', jdk: '11']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.249.x</artifactId>
-                <version>831.v9814430e6383</version>
+                <version>887.vae9c8ac09ff7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -104,6 +104,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>2.95-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/473 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.95-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/473 -->
+            <version>2.95-rc2630.52d4fd465e1a</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/473 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.95-rc2630.52d4fd465e1a</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/473 -->
+            <version>2633.v6baeedc13805</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -141,7 +141,7 @@ public class ExecutorPickle extends Pickle {
                 }
 
                 if (future.isCancelled()) {
-                    throw new AbortException("Queue item was canceled.");
+                    throw new FlowInterruptedException(Result.ABORTED, true, new ExecutorStepExecution.QueueTaskCancelled());
                 }
 
                 Queue.Executable exec = future.get();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -130,7 +130,7 @@ public class ExecutorPickle extends Pickle {
                         if (placeholder.getCookie() != null && Jenkins.get().getNode(placeholder.getAssignedLabel().getName()) == null ) {
                             if (System.nanoTime() > endTimeNanos) {
                                 Queue.getInstance().cancel(item);
-                                owner.getListener().getLogger().printf("Killed %s after waiting for %s because we assume unknown agent %s is never going to appear\n",
+                                owner.getListener().getLogger().printf("Killed %s after waiting for %s because we assume unknown agent %s is never going to appear%n",
                                         item.task.getDisplayName(), Util.getTimeSpanString(TIMEOUT_WAITING_FOR_NODE_MILLIS), placeholder.getAssignedLabel());
                                 throw new FlowInterruptedException(Result.ABORTED, new ExecutorStepExecution.RemovedNodeCause());
                             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -80,8 +80,10 @@ public class ExecutorPickleTest {
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 Queue.getInstance().cancel(items[0]);
-                j.waitForCompletion(b);
-                // Do not bother with assertBuildStatus; we do not really care whether it is ABORTED or FAILURE
+                j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
+                InterruptedBuildAction iba = b.getAction(InterruptedBuildAction.class);
+                assertNotNull(iba);
+                assertEquals(Collections.singleton(ExecutorStepExecution.QueueTaskCancelled.class), iba.getCauses().stream().map(Object::getClass).collect(Collectors.toSet()));
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickleTest.java
@@ -32,11 +32,13 @@ import hudson.model.User;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
+import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.durable_task.Messages;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 
@@ -45,13 +47,14 @@ import org.junit.Test;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.JenkinsSessionRule;
 
 import java.io.InterruptedIOException;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 public class ExecutorPickleTest {
 
@@ -141,8 +144,11 @@ public class ExecutorPickleTest {
                     Thread.sleep(ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS + 1000L);
                     Assert.assertEquals("Should have given up and killed the Task representing the resuming build", 0, Queue.getInstance().getItems().length );
                     Assert.assertFalse(run.isBuilding());
-                    j.assertBuildStatus(Result.FAILURE, run);
+                    j.assertBuildStatus(Result.ABORTED, run);
                     Assert.assertEquals(0, j.jenkins.getQueue().getItems().length);
+                    InterruptedBuildAction iba = run.getAction(InterruptedBuildAction.class);
+                    assertNotNull(iba);
+                    assertEquals(Collections.singleton(ExecutorStepExecution.RemovedNodeCause.class), iba.getCauses().stream().map(Object::getClass).collect(Collectors.toSet()));
                 } catch (InterruptedIOException ioe) {
                     throw new AssertionError("Waited for build to detect loss of node and it didn't!", ioe);
                 } finally {


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-cps-plugin/pull/473. Further refines #175 to use a specific `CauseOfInterruption` introduced in #104 for a related reason.

Before:

```
Resuming build at … after Jenkins restart
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
[Pipeline] End of Pipeline
ERROR: Killed part of p #1 after waiting for 15,000 ms because we assume unknown Node slave0 is never going to appear!
Finished: FAILURE
```

After:

```
Resuming build at … after Jenkins restart
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Waiting to resume part of p #1: ‘Jenkins’ doesn’t have label ‘slave0’
Killed part of p #1 after waiting for 15 sec because we assume unknown agent slave0 is never going to appear
[Pipeline] End of Pipeline
Agent was removed
Finished: ABORTED
```