### PR TITLE
Demonstration that implementing `getParentExecutable` is necessary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: '8'],
     [platform: 'windows', jdk: '8'],
-    [platform: 'linux', jdk: '11', jenkins: "2.277", javaLevel: 8]
+    [platform: 'linux', jdk: '11']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.19</version>
+        <version>4.30</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -67,7 +67,7 @@
     <properties>
         <revision>2.41</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.303.3</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -77,8 +77,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>831.v9814430e6383</version>
+                <artifactId>bom-2.303.x</artifactId>
+                <version>987.v4ade2e49fe70</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -917,8 +917,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return PlaceholderTask.this;
             }
 
-            // TODO https://github.com/jenkinsci/jenkins/pull/5733 @Override
-            public Queue.Executable getParentExecutable() {
+            @Override public Queue.Executable getParentExecutable() {
                 Run<?, ?> b = runForDisplay();
                 if (b instanceof Queue.Executable) {
                     return (Queue.Executable) b;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -26,10 +26,13 @@ package org.jenkinsci.plugins.workflow.support.steps;
 
 import com.gargoylesoftware.htmlunit.Page;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.model.Computer;
 import hudson.model.Executor;
+import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Node;
@@ -37,6 +40,7 @@ import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.Slave;
+import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.model.labels.LabelAtom;
 import hudson.model.queue.CauseOfBlockage;
@@ -74,13 +78,18 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import hudson.util.VersionNumber;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
+import jenkins.security.s2m.AdminWhitelistRule;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.groovy.JsonSlurper;
 import org.acegisecurity.Authentication;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.util.JavaEnvUtils;
 import static org.hamcrest.Matchers.*;
@@ -108,6 +117,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepExecutions;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Assume;
@@ -123,6 +137,7 @@ import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /** Tests pertaining to {@code node} and {@code sh} steps. */
 public class ExecutorStepTest {
@@ -1217,6 +1232,92 @@ public class ExecutorStepTest {
             assertEquals(b, exec.getClass().getMethod("getParentExecutable").invoke(exec)); // TODO https://github.com/jenkinsci/jenkins/pull/5733 remove reflection
             SemaphoreStep.success("wait/1", null);
         });
+    }
+
+    @Issue("SECURITY-2428")
+    @Test
+    public void accessPermittedOnlyFromCurrentBuild() throws Throwable {
+        sessions.then(r -> {
+            // Adapted from RunningBuildFilePathFilterTest
+            ExtensionList.lookupSingleton(AdminWhitelistRule.class).setMasterKillSwitch(false);
+            WorkflowJob main = r.createProject(WorkflowJob.class, "main");
+            DumbSlave s = r.createOnlineSlave();
+            main.setDefinition(new CpsFlowDefinition("node('" + s.getNodeName() + "') {writeBack()}", true));
+            // Normal case: writing to our own build directory
+            WriteBackStep.controllerFile = new File(main.getBuildDir(), "1/stuff.txt");
+            r.buildAndAssertSuccess(main);
+            // Attacks:
+            WriteBackStep.legal = false;
+            // Writing to someone else’s build directory (covered by RunningBuildFilePathFilter)
+            FreeStyleProject other = r.createFreeStyleProject("other");
+            r.buildAndAssertSuccess(other);
+            WriteBackStep.controllerFile = new File(other.getBuildByNumber(1).getRootDir(), "hack");
+            r.buildAndAssertSuccess(main);
+            // Writing to some other directory (covered by AdminWhitelistRule)
+            WriteBackStep.controllerFile = new File(r.jenkins.getRootDir(), "hack");
+            r.buildAndAssertSuccess(main);
+            // Writing to a sensitive file even in my own build dir (covered by AdminWhitelistRule)
+            WriteBackStep.controllerFile = new File(main.getBuildDir(), "4/build.xml");
+            r.buildAndAssertSuccess(main);
+            // Writing to the directory of an earlier build
+            WriteBackStep.controllerFile = new File(main.getBuildByNumber(1).getRootDir(), "stuff.txt");
+            r.buildAndAssertSuccess(main);
+        });
+    }
+    public static final class WriteBackStep extends Step {
+        static File controllerFile;
+        static boolean legal = true;
+        @DataBoundConstructor public WriteBackStep() {}
+        @Override public StepExecution start(StepContext context) throws Exception {
+            return StepExecutions.synchronous(context, c -> {
+                Run<?, ?> build = c.get(Run.class);
+                TaskListener listener = c.get(TaskListener.class);
+                hudson.Launcher launcher = c.get(hudson.Launcher.class);
+                listener.getLogger().println("Will try to write to " + controllerFile + "; legal? " + legal);
+                String text = build.getExternalizableId();
+                try {
+                    launcher.getChannel().call(new WriteBackCallable(new FilePath(controllerFile), text));
+                    if (legal) {
+                        assertEquals(text, FileUtils.readFileToString(controllerFile, StandardCharsets.UTF_8));
+                        listener.getLogger().println("Allowed as expected");
+                    } else {
+                        fail("should not have been allowed");
+                    }
+                } catch (Exception x) {
+                    if (!legal && x.toString().contains("https://www.jenkins.io/redirect/security-144")) {
+                        Functions.printStackTrace(x, listener.error("Rejected as expected!"));
+                    } else {
+                        throw x;
+                    }
+                }
+                return null;
+            });
+        }
+        @TestExtension("accessPermittedOnlyFromCurrentBuild") public static final class DescriptorImpl extends StepDescriptor {
+            @Override public String getFunctionName() {
+                return "writeBack";
+            }
+            @Override public Set<? extends Class<?>> getRequiredContext() {
+                return ImmutableSet.of(Run.class, TaskListener.class, hudson.Launcher.class);
+            }
+        }
+        private static final class WriteBackCallable extends MasterToSlaveCallable<Void, IOException> {
+            private final FilePath controllerFile;
+            private final String text;
+            WriteBackCallable(FilePath controllerFile, String text) {
+                this.controllerFile = controllerFile;
+                this.text = text;
+            }
+            @Override public Void call() throws IOException {
+                assertTrue(controllerFile.isRemote());
+                try {
+                    controllerFile.write(text, null);
+                } catch (InterruptedException x) {
+                    throw new IOException(x);
+                }
+                return null;
+            }
+        }
     }
 
     private static class MainAuthenticator extends QueueItemAuthenticator {


### PR DESCRIPTION
Proves that #170 is necessary to retain compatibility with some rare use cases after https://github.com/jenkinsci/jenkins/pull/5880: for example, Pipeline code coverage without https://github.com/jenkinsci/code-coverage-api-plugin/pull/245 or https://github.com/jenkinsci/cobertura-plugin/pull/130.
