### PR TITLE
Recover gracefully when a `PlaceholderTask` is in the queue but the associated build is complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
+        <jenkins-test-harness.version>1664.ve9ed23f5e0f2</jenkins-test-harness.version> <!-- TODO: https://github.com/jenkinsci/jenkins-test-harness/pull/353 -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
-        <jenkins-test-harness.version>1664.ve9ed23f5e0f2</jenkins-test-harness.version> <!-- TODO: https://github.com/jenkinsci/jenkins-test-harness/pull/353 -->
+        <jenkins-test-harness.version>1666.vd1360abbfe9e</jenkins-test-harness.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -426,9 +426,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             if (!stopping && run != null && !run.isLogUpdated()) {
                 stopping = true;
                 LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
-                Timer.get().execute(() -> {
-                    Queue.getInstance().cancel(this);
-                });
+                Timer.get().execute(() -> Queue.getInstance().cancel(this));
             }
             if (stopping) {
                 return new CauseOfBlockage() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -422,6 +422,22 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
+            Run<?, ?> run = runForDisplay();
+            if (!stopping && run != null && !run.isLogUpdated()) {
+                stopping = true;
+                LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
+                Timer.get().execute(() -> {
+                    Queue.getInstance().cancel(this);
+                });
+            }
+            if (stopping) {
+                return new CauseOfBlockage() {
+                    @Override
+                    public String getShortDescription() {
+                        return "Stopping " + getDisplayName();
+                    }
+                };
+            }
             return null;
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1269,7 +1269,7 @@ public class ExecutorStepTest {
         });
     }
 
-    @Ignore
+    @Ignore("TODO safe fix still TBD")
     @Test public void placeholderTaskInQueueButAssociatedBuildComplete() throws Throwable {
         AtomicReference<File> rootDir = new AtomicReference<>();
         Path tempQueueFile = Files.createTempFile("queue", ".xml");

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -128,7 +128,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Assume;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -1268,8 +1267,8 @@ public class ExecutorStepTest {
         });
     }
 
-    @Ignore("TODO safe fix still TBD")
     @Test public void placeholderTaskInQueueButAssociatedBuildComplete() throws Throwable {
+        logging.record(ExecutorStepExecution.class, Level.FINE).capture(50);
         Path tempQueueFile = tmp.newFile().toPath();
         sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -1300,7 +1299,10 @@ public class ExecutorStepTest {
             WorkflowRun b = p.getBuildByNumber(1);
             assertFalse(b.isLogUpdated());
             r.assertBuildStatusSuccess(b);
-            assertThat(Queue.getInstance().getItems(), emptyArray()); // This assertion fails.
+            while (Queue.getInstance().getItems().length > 0) {
+                Thread.sleep(100L);
+            }
+            assertThat(logging.getMessages(), hasItem(startsWith("Refusing to build ExecutorStepExecution.PlaceholderTask{runId=p#")));
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1289,6 +1289,8 @@ public class ExecutorStepTest {
             // Create a node with the correct label and let the build complete.
             DumbSlave node = r.createOnlineSlave(Label.get("custom-label"));
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
+            // Remove node so that tasks requiring custom-label are stuck in the queue.
+            Jenkins.get().removeNode(node);
         });
         // Copy the temp queue.xml over the real one. The associated build has already completed, so the queue now
         // has a bogus PlaceholderTask.


### PR DESCRIPTION
While testing Jenkins in various backup and restore scenarios, we ran into a case where the Jenkins queue contained a `ExecutorStepExecution.PlaceholderTask` whose associated build was already complete, causing the task to sit in the queue forever. We are not sure how this happened or how to reproduce it, but this PR adds a test that reproduces the same symptoms that may be useful for future investigation.

I did some experimentation to see if the issue could be fixed, and something like this does fix it but does not seem like the best approach:

```diff
diff --git a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
index c81bf0c..64ca128 100644
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -360,6 +360,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         private Object readResolve() {
+            Run<?, ?> run = runForDisplay();
+            if (run != null && !run.isLogUpdated()) {
+                return null;
+            }
             if (cookie != null) {
                 synchronized (runningTasks) {
                     runningTasks.put(cookie, new RunningTask());
```

A patch like this would cause Pipeline builds to be loaded and resumed from inside of `Queue.load` while the queue lock is held during Jenkins startup, which seems concerning. Accessing any context variables via `StepContext.get` would have the same problem because `CpsStepContext.doGet` transitively calls `getThreadGroupSynchronously` which has to load the `WorkflowRun` and resume the Pipeline. Perhaps we could expose `CpsStepContext.isComplete` as a new method on `StepContext` and check that instead, but I'm not sure. `Queue.load` [does explicitly handle the case where a task is null](https://github.com/jenkinsci/jenkins/blob/da7935d6cca1e48adbdea9ecae8c9a150e8ce5e8/core/src/main/java/hudson/model/Queue.java#L411), although maybe there is a better way to remove the task from the queue.

Given @jglick is working on stuff related to resumption of the `node` step in #180, it seems best not to try to make a speculative fix right now.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
