### PR TITLE
[JENKINS-67531] Do not load Pipelines during PlaceholderTask.getCauseOfBlockage in normal scenarios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>1112.v8bce30c92835</version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/188 -->
+            <version>1108.v57edf648f5d4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <version>1108.vb324320c17f9</version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/188 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>1108.vb324320c17f9</version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/188 -->
+            <version>1112.v8bce30c92835</version> <!-- https://github.com/jenkinsci/workflow-api-plugin/pull/188 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -423,15 +423,14 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
-            if (!FlowExecutionList.get().isResumptionComplete()) {
-                // We do not want to load the run and resume its execution in this context in normal scenarios.
-                return null;
-            }
-            Run<?, ?> run = runForDisplay();
-            if (!stopping && run != null && !run.isLogUpdated()) {
-                stopping = true;
-                LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
-                Timer.get().execute(() -> Queue.getInstance().cancel(this));
+            if (FlowExecutionList.get().isResumptionComplete()) {
+                // We only do this if resumption is complete so that we do not load the run and resume its execution in this context in normal scenarios.
+                Run<?, ?> run = runForDisplay();
+                if (!stopping && run != null && !run.isLogUpdated()) {
+                    stopping = true;
+                    LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
+                    Timer.get().execute(() -> Queue.getInstance().cancel(this));
+                }
             }
             if (stopping) {
                 return new CauseOfBlockage() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -64,6 +64,7 @@ import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -422,6 +423,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
+            if (!FlowExecutionList.get().isResumptionComplete()) {
+                // We do not want to load the run and resume its execution in this context in normal scenarios.
+                return null;
+            }
             Run<?, ?> run = runForDisplay();
             if (!stopping && run != null && !run.isLogUpdated()) {
                 stopping = true;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1299,6 +1299,7 @@ public class ExecutorStepTest {
             WorkflowRun b = p.getBuildByNumber(1);
             assertFalse(b.isLogUpdated());
             r.assertBuildStatusSuccess(b);
+            Queue.getInstance().maintain(); // Otherwise we may have to wait up to 5 seconds.
             while (Queue.getInstance().getItems().length > 0) {
                 Thread.sleep(100L);
             }


### PR DESCRIPTION
See [JENKINS-67351](https://issues.jenkins.io/browse/JENKINS-67351) and https://github.com/jenkinsci/workflow-api-plugin/pull/188. Amends https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185.

One of the stack traces related to JENKINS-67351 (from the jenkinsci-users mailing list) indicated that a build being accessed in `PlaceholderTask.getCauseOfBlockage` was not yet loaded because `FlowExecutionList$ItemListenerImpl.onLoaded` had not executed yet. I did not think this was possible in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185#discussion_r762246581, and we do not want to be loading Pipelines while the queue lock is held in normal scenarios.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
