### PR TITLE
Revert fixes related to JENKINS-67351 and JENKINS-67164

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -65,7 +65,6 @@ import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.QueueItemAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -424,14 +423,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
-            if (FlowExecutionList.get().isResumptionComplete()) {
-                // We only do this if resumption is complete so that we do not load the run and resume its execution in this context in normal scenarios.
-                Run<?, ?> run = runForDisplay();
-                if (!stopping && run != null && !run.isLogUpdated()) {
-                    stopping = true;
-                    LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
-                    Timer.get().execute(() -> Queue.getInstance().cancel(this));
-                }
+            Run<?, ?> run = runForDisplay();
+            if (!stopping && run != null && !run.isLogUpdated()) {
+                stopping = true;
+                LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
+                Timer.get().execute(() -> Queue.getInstance().cancel(this));
             }
             if (stopping) {
                 return new CauseOfBlockage() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -423,20 +423,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
-            Run<?, ?> run = runForDisplay();
-            if (!stopping && run != null && !run.isLogUpdated()) {
-                stopping = true;
-                LOGGER.warning(() -> "Refusing to build " + this + " and cancelling it because associated build is complete");
-                Timer.get().execute(() -> Queue.getInstance().cancel(this));
-            }
-            if (stopping) {
-                return new CauseOfBlockage() {
-                    @Override
-                    public String getShortDescription() {
-                        return "Stopping " + getDisplayName();
-                    }
-                };
-            }
             return null;
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1253,7 +1253,6 @@ public class ExecutorStepTest {
             WorkflowRun b = p.getBuildByNumber(1);
             assertFalse(b.isLogUpdated());
             r.assertBuildStatusSuccess(b);
-            Queue.getInstance().maintain(); // Otherwise we may have to wait up to 5 seconds.
             while (Queue.getInstance().getItems().length > 0) {
                 Thread.sleep(100L);
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -33,7 +33,6 @@ import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Item;
 import hudson.model.Job;
-import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Result;
@@ -75,7 +74,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import hudson.util.VersionNumber;
-import java.nio.file.StandardCopyOption;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import jenkins.security.QueueItemAuthenticator;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
@@ -1218,45 +1218,6 @@ public class ExecutorStepTest {
             assertNotNull(exec);
             assertEquals(b, exec.getParentExecutable());
             SemaphoreStep.success("wait/1", null);
-        });
-    }
-
-    @Test public void placeholderTaskInQueueButAssociatedBuildComplete() throws Throwable {
-        logging.record(ExecutorStepExecution.class, Level.FINE).capture(50);
-        Path tempQueueFile = tmp.newFile().toPath();
-        sessions.then(r -> {
-            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-            p.setDefinition(new CpsFlowDefinition("node('custom-label') { }", true));
-            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-            // Get into a state where a PlaceholderTask is in the queue.
-            while (true) {
-                Queue.Item[] items = Queue.getInstance().getItems();
-                if (items.length == 1 && items[0].task instanceof ExecutorStepExecution.PlaceholderTask) {
-                    break;
-                }
-                Thread.sleep(500L);
-            }
-            // Copy queue.xml to a temp file while the PlaceholderTask is in the queue.
-            r.jenkins.getQueue().save();
-            Files.copy(sessions.getHome().toPath().resolve("queue.xml"), tempQueueFile, StandardCopyOption.REPLACE_EXISTING);
-            // Create a node with the correct label and let the build complete.
-            DumbSlave node = r.createOnlineSlave(Label.get("custom-label"));
-            r.assertBuildStatusSuccess(r.waitForCompletion(b));
-            // Remove node so that tasks requiring custom-label are stuck in the queue.
-            Jenkins.get().removeNode(node);
-        });
-        // Copy the temp queue.xml over the real one. The associated build has already completed, so the queue now
-        // has a bogus PlaceholderTask.
-        Files.copy(tempQueueFile, sessions.getHome().toPath().resolve("queue.xml"), StandardCopyOption.REPLACE_EXISTING);
-        sessions.then(r -> {
-            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
-            WorkflowRun b = p.getBuildByNumber(1);
-            assertFalse(b.isLogUpdated());
-            r.assertBuildStatusSuccess(b);
-            while (Queue.getInstance().getItems().length > 0) {
-                Thread.sleep(100L);
-            }
-            assertThat(logging.getMessages(), hasItem(startsWith("Refusing to build ExecutorStepExecution.PlaceholderTask{runId=p#")));
         });
     }
 


### PR DESCRIPTION
Reverts #188 and #185 due to problems in https://github.com/jenkinsci/workflow-api-plugin/pull/188 (see https://github.com/jenkinsci/workflow-api-plugin/pull/188#issuecomment-1013382364) which have no obvious fix and so require the `workflow-api` PRs to be reverted.  https://github.com/jenkinsci/workflow-api-plugin/pull/188 introduced an API required here after #188, but that API will be removed once the workflow-api PRs are reverted, so we need to revert the PRs here as well.

These fixes were generally expected only to apply to uncommon scenarios related to disaster recovery (although they apparently also mattered for regular usage of ci.jenkins.io as mentioned in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/185#issuecomment-999703045), so I think it is ok to revert them for now.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
