### PR TITLE
[JENKINS-68080] Temporarily disable push mode tests on Java 17+

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -35,6 +35,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
+import hudson.util.VersionNumber;
 import io.jenkins.plugins.environment_filter_utils.util.BuilderUtil;
 import io.jenkins.plugins.generic_environment_filters.RemoveSpecificVariablesFilter;
 import io.jenkins.plugins.generic_environment_filters.VariableContributingFilter;
@@ -396,6 +397,10 @@ public class ShellStepTest {
 
     @Issue("JENKINS-38381")
     @Test public void remoteLogger() throws Exception {
+        Assume.assumeTrue(
+                "TODO JENKINS-68080 does not work on Java 17+",
+                new VersionNumber(System.getProperty("java.specification.version"))
+                        .isOlderThan(new VersionNumber("17")));
         DurableTaskStep.USE_WATCHING = true;
         assumeFalse(Functions.isWindows()); // TODO create Windows equivalent
         final String credentialsId = "creds";
@@ -501,6 +506,10 @@ public class ShellStepTest {
 
     @Issue("JENKINS-54133")
     @Test public void remoteConsoleNotes() throws Exception {
+        Assume.assumeTrue(
+                "TODO JENKINS-68080 does not work on Java 17+",
+                new VersionNumber(System.getProperty("java.specification.version"))
+                        .isOlderThan(new VersionNumber("17")));
         DurableTaskStep.USE_WATCHING = true;
         assumeFalse(Functions.isWindows()); // TODO create Windows equivalent
         j.createSlave("remote", null, null);
@@ -650,7 +659,12 @@ public class ShellStepTest {
             "    }\n" +
             "  }\n" +
             "}", true));
-            for (boolean watching : new boolean[] {false, true}) {
+        // TODO JENKINS-68080 does not work on Java 17+
+        boolean[] watchingConfig =
+                new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("17"))
+                        ? new boolean[] {false, true}
+                        : new boolean[] {false};
+            for (boolean watching : watchingConfig) {
                 DurableTaskStep.USE_WATCHING = watching;
                 String log = JenkinsRule.getLog(j.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new BooleanParameterValue("WATCHING", watching)))));
                 for (String node : new String[] {builtInNodeLabel, "remote"}) {


### PR DESCRIPTION
See [JENKINS-68080](https://issues.jenkins.io/browse/JENKINS-68080). I have discovered that the Pipeline: Nodes and Processes tests that enable watch mode consistently hang on Java 17. The default pull mode passes Java 17 tests. To unblock Java 17 testing, this PR skips such tests when running on Java 17. This is a temporary workaround. When JENKINS-68080 is resolved, this workaround can be deleted. I have verified in jenkinsci/bom#935 that with this PR Java 17 tests pass (by skipping the watch mode tests).