### PR TITLE
[JENKINS-68727] Require 2.332.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.303.3</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <jenkins-test-harness.version>1746.v2b_3c5d1983b_e</jenkins-test-harness.version> <!-- TODO until in plugin-pom -->
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -76,7 +76,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
+                <artifactId>bom-2.332.x</artifactId>
                 <version>1370.vfa_e23fe119c3</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>1162.va_1e49062a_00e</version>
+            <version>1164.v760c223ddb_32</version> <!-- TODO until in BOM -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-68727

Following up https://github.com/jenkinsci/workflow-api-plugin/pull/226 so that #226 is offered only to 2.332.x+ users.
