### PR TITLE
[JENKINS-49707] `AgentErrorCondition` improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
@@ -53,6 +53,9 @@ public final class AgentErrorCondition extends ErrorCondition {
     @DataBoundConstructor public AgentErrorCondition() {}
 
     @Override public boolean test(Throwable t, StepContext context) throws IOException, InterruptedException {
+        if (t instanceof AgentOfflineException) {
+            return true;
+        }
         if (t instanceof FlowInterruptedException && ((FlowInterruptedException) t).getCauses().stream().anyMatch(ExecutorStepExecution.RemovedNodeCause.class::isInstance)) {
             return true;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
@@ -56,7 +56,8 @@ public final class AgentErrorCondition extends ErrorCondition {
         if (t instanceof AgentOfflineException) {
             return true;
         }
-        if (t instanceof FlowInterruptedException && ((FlowInterruptedException) t).getCauses().stream().anyMatch(ExecutorStepExecution.RemovedNodeCause.class::isInstance)) {
+        if (t instanceof FlowInterruptedException && ((FlowInterruptedException) t).getCauses().stream().anyMatch(
+                c -> c instanceof ExecutorStepExecution.RemovedNodeCause || c instanceof ExecutorStepExecution.QueueTaskCancelled)) {
             return true;
         }
         if (isClosedChannel(t)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentOfflineException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentOfflineException.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import hudson.FilePath;
+import java.io.IOException;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+/**
+ * Inability to satisfy some request (such as {@link StepContext#get} on {@link FilePath}) because an agent is offline.
+ */
+final class AgentOfflineException extends IOException {
+
+    AgentOfflineException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -63,7 +63,7 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         if (f != null) {
             LOGGER.log(Level.FINE, "serving {0}:{1}", new Object[] {r.slave, r.path});
         } else {
-            IOException e = new IOException("Unable to create live FilePath for " + r.slave);
+            AgentOfflineException e = new AgentOfflineException("Unable to create live FilePath for " + r.slave);
             Computer c = Jenkins.get().getComputer(r.slave);
             if (c != null) {
                 for (Computer.TerminationRequest tr : c.getTerminatedBy()) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
@@ -69,7 +69,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Tests of retrying {@code node} blocks.
  */
-public class RetryExecutorStepTest {
+public class AgentErrorConditionTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
@@ -69,6 +69,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Tests of retrying {@code node} blocks.
  */
+@Issue("JENKINS-49707")
 public class AgentErrorConditionTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -76,7 +77,6 @@ public class AgentErrorConditionTest {
     @Rule public InboundAgentRule inboundAgents = new InboundAgentRule();
     @Rule public LoggerRule logging = new LoggerRule();
 
-    @Issue("JENKINS-49707")
     @Test public void retryNodeBlock() throws Throwable {
         sessions.then(r -> {
             logging.record(DurableTaskStep.class, Level.FINE).record(FileMonitoringTask.class, Level.FINE).record(ExecutorStepExecution.class, Level.FINE);
@@ -103,7 +103,6 @@ public class AgentErrorConditionTest {
         });
     }
 
-    @Issue("JENKINS-49707")
     @Test public void retryNodeBlockSynch() throws Throwable {
         sessions.then(r -> {
             logging.record(ExecutorStepExecution.class, Level.FINE);
@@ -159,7 +158,6 @@ public class AgentErrorConditionTest {
         }
     }
 
-    @Issue("JENKINS-49707")
     @Test public void agentOfflineWhenStartingStep() throws Throwable {
         sessions.then(r -> {
             Slave s = r.createSlave(Label.get("remote"));
@@ -186,7 +184,6 @@ public class AgentErrorConditionTest {
     }
 
     @Ignore("TODO pending https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180")
-    @Issue("JENKINS-49707")
     @Test public void retryNewStepAcrossRestarts() throws Throwable {
         logging.record(DurableTaskStep.class, Level.FINE).record(FileMonitoringTask.class, Level.FINE).record(ExecutorStepExecution.class, Level.FINE);
         sessions.then(r -> {
@@ -220,7 +217,7 @@ public class AgentErrorConditionTest {
     }
 
     @Ignore("TODO pending https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180")
-    @Issue({"JENKINS-49707", "JENKINS-30383"})
+    @Issue("JENKINS-30383")
     @Test public void retryNodeBlockSynchAcrossRestarts() throws Throwable {
         logging.record(ExecutorStepExecution.class, Level.FINE).record(FlowExecutionList.class, Level.FINE);
         sessions.then(r -> {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1103,7 +1103,7 @@ public class ExecutorStepTest {
             r.assertLogContains("hello", b);
             r.assertLogNotContains("world", b);
             r.assertLogContains("going offline", b);
-            r.assertLogContains("IOException: Unable to create live FilePath for " + agent.getNodeName(), b);
+            r.assertLogContains("AgentOfflineException: Unable to create live FilePath for " + agent.getNodeName(), b);
         });
     }
 


### PR DESCRIPTION
Make `retry(count: …, conditions: [agent()])` handle more cases:

* `Unable to create live FilePath…` which is observed sometimes before an agent is even used for the first time. (https://github.com/jenkins-infra/helpdesk/issues/2984#issuecomment-1178022133)
* The queue item for a `node` block was cancelled. While this _could_ be something that happened due to manual administrator intervention, typically it is a side effect of the cloud killing things off. `KubernetesAgentErrorCondition` (https://github.com/jenkinsci/kubernetes-plugin/pull/1190) already handles this because when a pod is removed, the cloud tried to clean up by removing the agent from the controller’s list of nodes (already handled) _and_ cancelling any outstanding queue items associated with it, but the order is tricky to predict. Note that aborting the overall _build_ is something different.