### PR TITLE
Handle `ChannelClosedException` in `AgentErrorCondition`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
@@ -30,6 +30,7 @@ import hudson.Launcher;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Node;
+import hudson.remoting.ChannelClosedException;
 import hudson.slaves.WorkspaceList;
 import java.io.EOFException;
 import java.io.IOException;
@@ -76,6 +77,8 @@ public final class AgentErrorCondition extends ErrorCondition {
 
     private static boolean isClosedChannel(Throwable t) {
         if (t instanceof ClosedChannelException) {
+            return true;
+        } else if (t instanceof ChannelClosedException) {
             return true;
         } else if (t instanceof EOFException) {
             return true;


### PR DESCRIPTION
Amends #231.

Normally `AgentErrorConditionTest.retryNodeBlockSynch` retries after an exception like this (line numbers adjusted for 2.346.x), where the cause is a `ClosedChannelException`:

```
java.nio.channels.ClosedChannelException
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onReadClosed(ChannelApplicationLayer.java:240)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.onRecvClosed(ApplicationLayer.java:221)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecvClosed(ProtocolStack.java:825)
	at org.jenkinsci.remoting.protocol.FilterLayer.onRecvClosed(FilterLayer.java:289)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.onRecvClosed(SSLEngineFilterLayer.java:177)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.switchToNoSecure(SSLEngineFilterLayer.java:279)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processWrite(SSLEngineFilterLayer.java:501)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processQueuedWrites(SSLEngineFilterLayer.java:244)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.doSend(SSLEngineFilterLayer.java:196)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.doCloseSend(SSLEngineFilterLayer.java:209)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.doCloseSend(ProtocolStack.java:793)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.doCloseWrite(ApplicationLayer.java:172)
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.closeWrite(ChannelApplicationLayer.java:342)
	at hudson.remoting.Channel.close(Channel.java:1494)
	at hudson.remoting.Channel.close(Channel.java:1447)
	at hudson.slaves.SlaveComputer.closeChannel(SlaveComputer.java:923)
	at hudson.slaves.SlaveComputer.access$100(SlaveComputer.java:112)
	at hudson.slaves.SlaveComputer$2.run(SlaveComputer.java:803)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
Caused: java.io.IOException: Backing channel 'JNLP4-connect connection from localhost/127.0.0.1:…' is disconnected.
	at hudson.remoting.RemoteInvocationHandler.channelOrFail(RemoteInvocationHandler.java:215)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:285)
	at com.sun.proxy.$Proxy63.isAlive(Unknown Source)
	at hudson.Launcher$RemoteLauncher$ProcImpl.isAlive(Launcher.java:1215)
	at hudson.Launcher$RemoteLauncher$ProcImpl.join(Launcher.java:1207)
	at org.jenkinsci.plugins.workflow.support.steps.AgentErrorConditionTest$HangStep.lambda$start$60c472c8$1(AgentErrorConditionTest.java:148)
	at org.jenkinsci.plugins.workflow.steps.StepExecutions$2.run(StepExecutions.java:61)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

In a PCT run I observed a test failure whereby the following exception was thrown and not recognized as retryable because the cause was a `ChannelClosedException`:

```
hudson.remoting.ChannelClosedException: Channel "unknown": Protocol stack cannot write data anymore. It is not open for write
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.write(ChannelApplicationLayer.java:333)
	at hudson.remoting.AbstractByteBufferCommandTransport.write(AbstractByteBufferCommandTransport.java:303)
	at hudson.remoting.Channel.send(Channel.java:765)
	at hudson.remoting.Channel.close(Channel.java:1480)
	at hudson.remoting.Channel.close(Channel.java:1447)
	at hudson.slaves.SlaveComputer.closeChannel(SlaveComputer.java:923)
	at hudson.slaves.SlaveComputer.access$100(SlaveComputer.java:112)
	at hudson.slaves.SlaveComputer$2.run(SlaveComputer.java:803)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
Caused: java.io.IOException: Backing channel 'JNLP4-connect connection from localhost/127.0.0.1:…' is disconnected.
	at hudson.remoting.RemoteInvocationHandler.channelOrFail(RemoteInvocationHandler.java:215)
	at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:285)
	at com.sun.proxy.$Proxy64.isAlive(Unknown Source)
	at hudson.Launcher$RemoteLauncher$ProcImpl.isAlive(Launcher.java:1215)
	at hudson.Launcher$RemoteLauncher$ProcImpl.join(Launcher.java:1207)
	at org.jenkinsci.plugins.workflow.steps.RetryExecutorStepTest$HangStep.lambda$start$60c472c8$1(RetryExecutorStepTest.java:140)
	at org.jenkinsci.plugins.workflow.steps.StepExecutions$2.run(StepExecutions.java:61)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

While I cannot reproduce this locally, it seems there is some timing-dependent behavior in `Channel.close` (https://github.com/jenkinsci/remoting/blob/7a10c6b6ca12fcd0f6a7280cfdac0d87e10b1364/src/main/java/hudson/remoting/Channel.java#L1480-L1494). Note that `close` actually discards both of these exceptions (https://github.com/jenkinsci/remoting/blob/7a10c6b6ca12fcd0f6a7280cfdac0d87e10b1364/src/main/java/hudson/remoting/Channel.java#L1495-L1502), but they are stored by `Channel.terminate` and later thrown up (https://github.com/jenkinsci/remoting/blob/7a10c6b6ca12fcd0f6a7280cfdac0d87e10b1364/src/main/java/hudson/remoting/RemoteInvocationHandler.java#L215).

https://github.com/jenkinsci/jenkins/pull/6555 expanded the set of exceptions in a similar way.
