### PR TITLE
Improve `ShellStepTest.label` with Hamcrest

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -361,16 +361,9 @@ public class ShellStepTest {
         
         WorkflowRun b = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        boolean found = false;
         FlowGraphTable t = new FlowGraphTable(b.getExecution());
         t.build();
-        for (Row r : t.getRows()) {
-            if (r.getDisplayName().contains("Step with label")) {
-                found = true;
-            }
-        }
-
-        assertTrue(found);
+        assertThat(t.getRows().stream().map(Row::getDisplayName).toArray(String[]::new), hasItemInArray(containsString("Step with label")));
     }
     
     @Test public void labelShortened() throws Exception {
@@ -382,16 +375,9 @@ public class ShellStepTest {
         
         WorkflowRun b = j.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        boolean found = false;
         FlowGraphTable t = new FlowGraphTable(b.getExecution());
         t.build();
-        for (Row r : t.getRows()) {
-            if (r.getDisplayName().contains(singleLabel)) {
-                found = true;
-            }
-        }
-
-        assertTrue(found);
+        assertThat(t.getRows().stream().map(Row::getDisplayName).toArray(String[]::new), hasItemInArray(containsString(singleLabel)));
     }
 
     @Issue("JENKINS-38381")


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/250#discussion_r924871316 now would fail like

```
Expected: an array containing a string containing "(some other text)"
     but: mismatches were: [was "Start of Pipeline", was "node", was "node block", was "isUnix", was "sh (Step with label)"]
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.jenkinsci.plugins.workflow.steps.durable_task.ShellStepTest.label(ShellStepTest.java:366)
```
