### PR TITLE
[JENKINS-49707] `retry` without conditions should handle node removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.332.1</jenkins.version>
+        <jenkins.version>2.346.1</jenkins.version>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
@@ -75,7 +75,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
+                <artifactId>bom-2.346.x</artifactId>
                 <version>1478.v81d3dc4f9a_43</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/124 -->
+            <version>630.vdd28011769da_</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/124 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/570 -->
+            <version>2756.v639b_85967348</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/570 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
+            <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/124 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -102,6 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>999999-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/570 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>630.vdd28011769da_</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/124 -->
+            <version>639.v6eca_cd8c04a_a_</version> <!-- TODO until in BOM -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2756.v639b_85967348</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/570 -->
+            <version>2759.v87459c4eea_ca_</version> <!-- TODO until in BOM -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -287,7 +287,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             continue;
                         }
                         listener.getLogger().println("Agent " + node.getNodeName() + " was deleted; cancelling node body");
-                        body.cancel(new FlowInterruptedException(Result.ABORTED, false, new RemovedNodeCause()));
+                        if (Util.isOverridden(BodyExecution.class, body.getClass(), "cancel", Throwable.class)) {
+                            body.cancel(new FlowInterruptedException(Result.ABORTED, false, new RemovedNodeCause()));
+                        } else { // TODO remove once https://github.com/jenkinsci/workflow-cps-plugin/pull/570 is widely deployed
+                            body.cancel(new RemovedNodeCause());
+                        }
                     }
                 }
             }, ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -287,7 +287,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             continue;
                         }
                         listener.getLogger().println("Agent " + node.getNodeName() + " was deleted; cancelling node body");
-                        body.cancel(new RemovedNodeCause());
+                        body.cancel(new FlowInterruptedException(Result.ABORTED, false, new RemovedNodeCause()));
                     }
                 }
             }, ExecutorPickle.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
@@ -223,7 +223,7 @@ public class AgentErrorConditionTest {
             r.waitForMessage("+ sleep", b);
             inboundAgents.stop("dumbo1");
             r.jenkins.removeNode(s);
-            r.waitForMessage(RetryThis.MESSAGE, b);
+            r.waitForMessage("Retrying", b);
             s = inboundAgents.createAgent(r, "dumbo2");
             s.setLabelString("dumb");
             r.jenkins.updateNode(s);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
@@ -206,7 +206,6 @@ public class AgentErrorConditionTest {
         });
     }
 
-    @Ignore("TODO RemovedNodeListener implicitly passes actualInterruption=true")
     @Test public void retryUnconditionally() throws Throwable {
         sessions.then(r -> {
             Slave s = inboundAgents.createAgent(r, "dumbo1");

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorConditionTest.java
@@ -206,6 +206,32 @@ public class AgentErrorConditionTest {
         });
     }
 
+    @Ignore("TODO RemovedNodeListener implicitly passes actualInterruption=true")
+    @Test public void retryUnconditionally() throws Throwable {
+        sessions.then(r -> {
+            Slave s = inboundAgents.createAgent(r, "dumbo1");
+            s.setLabelString("dumb");
+            r.jenkins.updateNode(s);
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "retry(2) {\n" +
+                "  node('dumb') {\n" +
+                "    if (isUnix()) {sh 'sleep 10'} else {bat 'echo + sleep && ping -n 10 localhost'}\n" +
+                "  }\n" +
+                "}", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            r.waitForMessage("+ sleep", b);
+            inboundAgents.stop("dumbo1");
+            r.jenkins.removeNode(s);
+            r.waitForMessage(RetryThis.MESSAGE, b);
+            s = inboundAgents.createAgent(r, "dumbo2");
+            s.setLabelString("dumb");
+            r.jenkins.updateNode(s);
+            r.waitForMessage("Running on dumbo2 in ", b);
+            r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        });
+    }
+
     @Test public void overallBuildCancelIgnored() throws Throwable {
         sessions.then(r -> {
             r.createSlave(Label.get("remote"));


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-step-api-plugin/pull/124, and https://github.com/jenkinsci/workflow-cps-plugin/pull/570 to be effective.

https://github.com/jenkins-infra/helpdesk/issues/3031#issuecomment-1175343746 noted earlier in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180#discussion_r914058932. If you have

```groovy
retry(2) { // no conditions: […]
  node('remote') {
    sh 'work
  }
}
```

and the agent is removed, the block was surprisingly not retried. This is because `actualInterruption` defaults to true for compatibility in https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 and `BodyExecution.cancel(CauseOfInterruption...)` does not override that.