### PR TITLE
[JENKINS-69936] Handle mixture of nested `node`, `dir`, & `ws`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -149,14 +149,17 @@ public final class ExecutorStepDynamicContext implements Serializable {
 
     }
 
-    /**
-     * @deprecated Not used for new builds, only those for which {@link ExecutorStepExecution} used {@link ExecutorStepDynamicContext} without {@link FilePathDynamicContext}.
-     */
-    @Deprecated
-    @Extension(ordinal = -1000) public static final class FilePathTranslator extends Translator<FilePath> {
+    @Extension public static final class FilePathTranslator extends Translator<FilePath> {
 
         @Override protected Class<FilePath> type() {
             return FilePath.class;
+        }
+
+        @Override protected FilePath get(DelegatedContext context) throws IOException, InterruptedException {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("ESDC=" + context.get(ExecutorStepDynamicContext.class) + " FPR=" + context.get(FilePathDynamicContext.FilePathRepresentation.class));
+            }
+            return super.get(context);
         }
 
         @Override FilePath get(ExecutorStepDynamicContext c) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -56,7 +56,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Persistent representation for context of {@link ExecutorStepExecution}.
- * Supersedes {@link FilePathDynamicContext} (never mind {@link org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle}),
+ * Supersedes {@link org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle},
  * {@link org.jenkinsci.plugins.workflow.support.pickles.ExecutorPickle},
  * {@link org.jenkinsci.plugins.workflow.support.pickles.ComputerPickle},
  * and {@link org.jenkinsci.plugins.workflow.support.pickles.WorkspaceListLeasePickle}.
@@ -149,17 +149,14 @@ public final class ExecutorStepDynamicContext implements Serializable {
 
     }
 
-    @Extension public static final class FilePathTranslator extends Translator<FilePath> {
+    /**
+     * @deprecated Not used for new builds, only those for which {@link ExecutorStepExecution} used {@link ExecutorStepDynamicContext} without {@link FilePathDynamicContext}.
+     */
+    @Deprecated
+    @Extension(ordinal = -1000) public static final class FilePathTranslator extends Translator<FilePath> {
 
         @Override protected Class<FilePath> type() {
             return FilePath.class;
-        }
-
-        @Override protected FilePath get(DelegatedContext context) throws IOException, InterruptedException {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("ESDC=" + context.get(ExecutorStepDynamicContext.class) + " FPR=" + context.get(FilePathDynamicContext.FilePathRepresentation.class));
-            }
-            return super.get(context);
         }
 
         @Override FilePath get(ExecutorStepDynamicContext c) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -131,6 +131,10 @@ public final class ExecutorStepDynamicContext implements Serializable {
         LOGGER.fine(() -> "fully restored for " + path + " on " + node);
     }
 
+    @Override public String toString() {
+        return "ExecutorStepDynamicContext[" + path + "@" + node + "]";
+    }
+
     private static abstract class Translator<T> extends DynamicContext.Typed<T> {
 
         @Override protected T get(DelegatedContext context) throws IOException, InterruptedException {
@@ -149,6 +153,13 @@ public final class ExecutorStepDynamicContext implements Serializable {
 
         @Override protected Class<FilePath> type() {
             return FilePath.class;
+        }
+
+        @Override protected FilePath get(DelegatedContext context) throws IOException, InterruptedException {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine("ESDC=" + context.get(ExecutorStepDynamicContext.class) + " FPR=" + context.get(FilePathDynamicContext.FilePathRepresentation.class));
+            }
+            return super.get(context);
         }
 
         @Override FilePath get(ExecutorStepDynamicContext c) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -917,7 +917,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         withExecution(execution -> {
                             execution.state = state;
                             execution.body = context.newBodyInvoker()
-                                .withContexts(env, state)
+                                .withContexts(env, state, FilePathDynamicContext.createContextualObject(workspace))
                                 .withCallback(new Callback(cookie, execution))
                                 .start();
                             LOGGER.fine(() -> "started " + cookie + " in " + runId);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -917,7 +917,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         withExecution(execution -> {
                             execution.state = state;
                             execution.body = context.newBodyInvoker()
-                                .withContexts(env, state, FilePathDynamicContext.createContextualObject(workspace))
+                                .withContexts(env, state)
                                 .withCallback(new Callback(cookie, execution))
                                 .start();
                             LOGGER.fine(() -> "started " + cookie + " in " + runId);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -55,6 +55,9 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
     }
 
     @Override protected FilePath get(DelegatedContext context) throws IOException, InterruptedException {
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine("ESDC=" + context.get(ExecutorStepDynamicContext.class) + " FPR=" + context.get(FilePathDynamicContext.FilePathRepresentation.class));
+        }
         FilePathRepresentation r = context.get(FilePathRepresentation.class);
         if (r == null) {
             return null;
@@ -89,7 +92,7 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         return new FilePathRepresentation(FilePathUtils.getNodeName(f), f.getRemote());
     }
 
-    private static final class FilePathRepresentation implements Serializable {
+    static final class FilePathRepresentation implements Serializable {
 
         private static final long serialVersionUID = 1;
 
@@ -99,6 +102,10 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         FilePathRepresentation(String slave, String path) {
             this.slave = slave;
             this.path = path;
+        }
+
+        @Override public String toString() {
+            return "FilePathRepresentation[" + path + "@" + slave + "]";
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -45,7 +45,7 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
  * Allows a step body to save a representation of a workspace
  * without forcing a particular {@link FilePath#getChannel} to be used the whole time.
  */
-@Extension(ordinal = 100) public final class FilePathDynamicContext extends DynamicContext.Typed<FilePath> {
+@Extension public final class FilePathDynamicContext extends DynamicContext.Typed<FilePath> {
 
     private static final Logger LOGGER = Logger.getLogger(FilePathDynamicContext.class.getName());
 
@@ -92,7 +92,7 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         return new FilePathRepresentation(FilePathUtils.getNodeName(f), f.getRemote());
     }
 
-    static final class FilePathRepresentation implements Serializable {
+    private static final class FilePathRepresentation implements Serializable {
 
         private static final long serialVersionUID = 1;
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -164,6 +164,7 @@ public class ExecutorStepDynamicContextTest {
     @Issue("JENKINS-69936")
     @Test public void nestedNode() throws Throwable {
         sessions.then(j -> {
+            logging.record(ExecutorStepDynamicContext.class, Level.FINE).record(FilePathDynamicContext.class, Level.FINE);
             DumbSlave alpha = j.createSlave("alpha", null, null);
             DumbSlave beta = j.createSlave("beta", null, null);
             j.waitOnline(alpha);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -161,4 +161,25 @@ public class ExecutorStepDynamicContextTest {
         });
     }
 
+    @Issue("JENKINS-69936")
+    @Test public void nestedNode() throws Throwable {
+        sessions.then(j -> {
+            DumbSlave alpha = j.createSlave("alpha", null, null);
+            DumbSlave beta = j.createSlave("beta", null, null);
+            j.waitOnline(alpha);
+            j.waitOnline(beta);
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {echo(/here ${pwd()}/)}}", true));
+            j.assertLogContains("here " + beta.getWorkspaceFor(p).getRemote(), j.buildAndAssertSuccess(p));
+            p.setDefinition(new CpsFlowDefinition("node('alpha') {ws('alphadir') {node('beta') {echo(/here ${pwd()}/)}}}", true));
+            j.assertLogContains("here " + beta.getWorkspaceFor(p).getRemote(), j.buildAndAssertSuccess(p));
+            p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {ws('betadir') {echo(/here ${pwd()}/)}}}", true));
+            j.assertLogContains("here " + beta.getRootPath().child("betadir").getRemote(), j.buildAndAssertSuccess(p));
+            p.setDefinition(new CpsFlowDefinition("node('alpha') {dir('alphadir') {node('beta') {echo(/here ${pwd()}/)}}}", true));
+            j.assertLogContains("here " + beta.getWorkspaceFor(p).getRemote(), j.buildAndAssertSuccess(p));
+            p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {dir('betadir') {echo(/here ${pwd()}/)}}}", true));
+            j.assertLogContains("here " + beta.getWorkspaceFor(p).child("betadir").getRemote(), j.buildAndAssertSuccess(p));
+        });
+    }
+
 }


### PR DESCRIPTION
[JENKINS-69936](https://issues.jenkins.io/browse/JENKINS-69936): amending https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180#discussion_r966433158 by ignoring a `FilePathRepresentation` which does not match the node name of the nearest enclosing `ExecutorStepDynamicContext`. Currently `DelegatedContext` lacks an exposed notion of depth, so if both contextual objects are present at different depths, we cannot tell which is deeper.