### PR TITLE
Implement `SubTask.getOwnerExecutable`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -429,6 +429,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return j.getNode(label);
         }
 
+        @Deprecated
         @Override public boolean isBuildBlocked() {
             return false;
         }
@@ -535,6 +536,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return hasPermission(Item.CANCEL);
         }
 
+        /**
+         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin).
+         */
+        @Deprecated
         public @CheckForNull Run<?,?> run() {
             try {
                 if (!context.isReady()) {
@@ -548,6 +553,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
         }
 
+        /**
+         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin).
+         */
+        @Deprecated
         public @CheckForNull Run<?,?> runForDisplay() {
             Run<?,?> r = run();
             if (r == null && /* not stored prior to 1.13 */runId != null) {
@@ -558,6 +567,13 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 }
             }
             return r;
+        }
+
+        // TODO https://github.com/jenkinsci/jenkins/pull/7599 @Override
+        public @CheckForNull Queue.Executable getOwnerExecutable() {
+            Run<?, ?> r = runForDisplay();
+            System.err.println("TODO gOE " + r);
+            return r instanceof Queue.Executable ? (Queue.Executable) r : null;
         }
 
         @Exported
@@ -721,7 +737,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public long getEstimatedDuration() {
-            Run<?,?> r = run();
+            Run<?,?> r = runForDisplay();
             // Not accurate if there are multiple agents in one build, but better than nothing:
             return r != null ? r.getEstimatedDuration() : -1;
         }
@@ -997,12 +1013,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
 
             @Override public Queue.Executable getParentExecutable() {
-                Run<?, ?> b = runForDisplay();
-                if (b instanceof Queue.Executable) {
-                    return (Queue.Executable) b;
-                } else {
-                    return null;
-                }
+                return getOwnerExecutable();
             }
 
             @Exported

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -569,7 +569,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return r;
         }
 
-        // TODO https://github.com/jenkinsci/jenkins/pull/7599 @Override
+        // TODO 2.389+ @Override
         public @CheckForNull Queue.Executable getOwnerExecutable() {
             Run<?, ?> r = runForDisplay();
             return r instanceof Queue.Executable ? (Queue.Executable) r : null;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -572,7 +572,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         // TODO https://github.com/jenkinsci/jenkins/pull/7599 @Override
         public @CheckForNull Queue.Executable getOwnerExecutable() {
             Run<?, ?> r = runForDisplay();
-            System.err.println("TODO gOE " + r);
             return r instanceof Queue.Executable ? (Queue.Executable) r : null;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -537,7 +537,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         /**
-         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin).
+         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin) if your core dep is 2.389+
          */
         @Deprecated
         public @CheckForNull Run<?,?> run() {
@@ -554,7 +554,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         /**
-         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin).
+         * @deprecated use {@link #getOwnerExecutable} (which does not require a dependency on this plugin) if your core dep is 2.389+
          */
         @Deprecated
         public @CheckForNull Run<?,?> runForDisplay() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -613,7 +613,7 @@ public class ExecutorStepTest {
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 assertEquals(p, items[0].task.getOwnerTask());
-                // // TODO https://github.com/jenkinsci/jenkins/pull/7599 remove cast
+                // // TODO 2.389+ remove cast
                 assertEquals(b, ((ExecutorStepExecution.PlaceholderTask) items[0].task).getOwnerExecutable());
                 assertEquals(items[0], QueueItemAction.getQueueItem(executorStartNode));
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -613,6 +613,7 @@ public class ExecutorStepTest {
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 assertEquals(p, items[0].task.getOwnerTask());
+                assertEquals(b, items[0].task.getOwnerExecutable());
                 assertEquals(items[0], QueueItemAction.getQueueItem(executorStartNode));
 
                 assertTrue(Queue.getInstance().cancel(items[0]));

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -613,7 +613,8 @@ public class ExecutorStepTest {
                 Queue.Item[] items = Queue.getInstance().getItems();
                 assertEquals(1, items.length);
                 assertEquals(p, items[0].task.getOwnerTask());
-                assertEquals(b, items[0].task.getOwnerExecutable());
+                // // TODO https://github.com/jenkinsci/jenkins/pull/7599 remove cast
+                assertEquals(b, ((ExecutorStepExecution.PlaceholderTask) items[0].task).getOwnerExecutable());
                 assertEquals(items[0], QueueItemAction.getQueueItem(executorStartNode));
 
                 assertTrue(Queue.getInstance().cancel(items[0]));


### PR DESCRIPTION
Implements the API introduced in https://github.com/jenkinsci/jenkins/pull/7599, for now without requiring a newer core dep.