### PR TITLE
[JENKINS-70528] Reproducing `FilePathDynamicContext`-related bug in test

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -70,7 +70,7 @@ public final class ExecutorStepDynamicContext implements Serializable {
 
     final @NonNull ExecutorStepExecution.PlaceholderTask task;
     final @NonNull String node;
-    private final @NonNull String path;
+    final @NonNull String path;
     /** Non-null after {@link #resume} if all goes well. */
     private transient @Nullable Executor executor;
     /** Non-null after {@link #resume} if all goes well. */

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java
@@ -64,6 +64,8 @@ import org.jenkinsci.plugins.workflow.support.pickles.FilePathPickle;
         if (esdc != null && !esdc.node.equals(r.slave)) {
             LOGGER.fine(() -> "skipping " + r.path + "@" + r.slave + " since it is on a different node than " + esdc.node);
             return null;
+        } else if (esdc != null && !esdc.path.equals(r.path)) {
+            LOGGER.fine(() -> "not skipping " + r.path + "@" + r.slave + " even though it is in a different workspace than " + esdc.node + "@" + esdc.path);
         }
         FilePath f = FilePathUtils.find(r.slave, r.path);
         if (f != null) {


### PR DESCRIPTION
#270 handled the common case that the nested `node` blocks actually ran on distinct agents. It is however possible (when agents have multiple executors) for the nested `node` to run in a new workspace on the _same_ agent: [JENKINS-70528](https://issues.jenkins.io/browse/JENKINS-70528). Trying to extend the earlier fix to handle this case just breaks `ws` and `dir` steps.