### PR TITLE
[JENKINS-70528] `node` / `dir` / `node` on same agent sets PWD to that of `dir` rather than `@2` workspace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-basic-steps</artifactId>
-                <version>999999-SNAPSHOT</version> <!-- TODO -->
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-basic-steps</artifactId>
+                <version>999999-SNAPSHOT</version> <!-- TODO -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -71,17 +71,19 @@ public final class ExecutorStepDynamicContext implements Serializable {
     final @NonNull ExecutorStepExecution.PlaceholderTask task;
     final @NonNull String node;
     final @NonNull String path;
+    final int depth;
     /** Non-null after {@link #resume} if all goes well. */
     private transient @Nullable Executor executor;
     /** Non-null after {@link #resume} if all goes well. */
     private transient @Nullable WorkspaceList.Lease lease;
 
-    ExecutorStepDynamicContext(ExecutorStepExecution.PlaceholderTask task, WorkspaceList.Lease lease, Executor executor) {
+    ExecutorStepDynamicContext(ExecutorStepExecution.PlaceholderTask task, WorkspaceList.Lease lease, Executor executor, int depth) {
         this.task = task;
         this.node = FilePathUtils.getNodeName(lease.path);
         this.path = lease.path.getRemote();
         this.executor = executor;
         this.lease = lease;
+        this.depth = depth;
     }
 
     void resume(StepContext context) throws Exception {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -914,9 +914,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             env.put("WORKSPACE_TMP", tempDir.getRemote()); // JENKINS-60634
                         }
                         FlowNode flowNode = context.get(FlowNode.class);
-                        if (flowNode != null) {
-                            flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
-                        }
+                        flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
                         listener.getLogger().println("Running on " + ModelHyperlinkNote.encodeTo(node) + " in " + workspace);
                         ExecutorStepDynamicContext state = new ExecutorStepDynamicContext(PlaceholderTask.this, lease, exec, FilePathDynamicContext.depthOf(flowNode));
                         withExecution(execution -> {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -918,7 +918,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             flowNode.addAction(new WorkspaceActionImpl(workspace, flowNode));
                         }
                         listener.getLogger().println("Running on " + ModelHyperlinkNote.encodeTo(node) + " in " + workspace);
-                        ExecutorStepDynamicContext state = new ExecutorStepDynamicContext(PlaceholderTask.this, lease, exec);
+                        ExecutorStepDynamicContext state = new ExecutorStepDynamicContext(PlaceholderTask.this, lease, exec, FilePathDynamicContext.depthOf(flowNode));
                         withExecution(execution -> {
                             execution.state = state;
                             execution.body = context.newBodyInvoker()

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/PushdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/PushdStep.java
@@ -30,6 +30,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import java.util.Set;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -72,7 +73,7 @@ public class PushdStep extends Step {
         }
 
         @Override public Set<? extends Class<?>> getRequiredContext() {
-            return Set.of(TaskListener.class, FilePath.class);
+            return Set.of(TaskListener.class, FilePath.class, FlowNode.class);
         }
         
         @Override public Set<? extends Class<?>> getProvidedContext() {
@@ -95,7 +96,7 @@ public class PushdStep extends Step {
             FilePath dir = getContext().get(FilePath.class).child(path);
             getContext().get(TaskListener.class).getLogger().println("Running in " + dir);
             getContext().newBodyInvoker()
-                .withContext(FilePathDynamicContext.createContextualObject(dir))
+                .withContext(FilePathDynamicContext.createContextualObject(dir, getContext().get(FlowNode.class)))
                 // Could use a dedicated BodyExecutionCallback here if we wished to print a message at the end ("Returning to ${cwd}"):
                 .withCallback(BodyExecutionCallback.wrap(getContext()))
                 .start();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStepExecution.java
@@ -73,7 +73,7 @@ public class WorkspaceStepExecution extends AbstractStepExecutionImpl {
         getContext().newBodyInvoker()
                 .withContexts(
                     EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), EnvironmentExpander.constant(env)),
-                    FilePathDynamicContext.createContextualObject(workspace))
+                    FilePathDynamicContext.createContextualObject(workspace, flowNode))
                 .withCallback(new Callback(lease))
                 .start();
         return false;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -197,17 +197,11 @@ public class ExecutorStepDynamicContextTest {
             p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {echo(/here ${pwd()}!/)}}", true));
             j.assertLogContains("here " + big.getWorkspaceFor(p).getRemote() + "@2!", j.buildAndAssertSuccess(p));
             p.setDefinition(new CpsFlowDefinition("node('alpha') {ws('alphadir') {node('beta') {echo(/here ${pwd()}!/)}}}", true));
-            /* TODO does not yet work; FilePathDynamicContext from ws('alphadir') takes precedence:
             j.assertLogContains("here " + big.getWorkspaceFor(p).getRemote() + "@2!", j.buildAndAssertSuccess(p));
-            */
-            j.assertLogContains("here " + big.getRootPath().child("alphadir").getRemote() + "!", j.buildAndAssertSuccess(p));
             p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {ws('betadir') {echo(/here ${pwd()}!/)}}}", true));
             j.assertLogContains("here " + big.getRootPath().child("betadir").getRemote() + "!", j.buildAndAssertSuccess(p));
             p.setDefinition(new CpsFlowDefinition("node('alpha') {dir('alphadir') {node('beta') {echo(/here ${pwd()}!/)}}}", true));
-            /* TODO same, with dir('alphadir'):
             j.assertLogContains("here " + big.getWorkspaceFor(p).getRemote() + "@2!", j.buildAndAssertSuccess(p));
-            */
-            j.assertLogContains("here " + big.getWorkspaceFor(p).child("alphadir").getRemote() + "!", j.buildAndAssertSuccess(p));
             p.setDefinition(new CpsFlowDefinition("node('alpha') {node('beta') {dir('betadir') {echo(/here ${pwd()}!/)}}}", true));
             j.assertLogContains("here " + big.getWorkspaceFor(p).sibling(big.getWorkspaceFor(p).getBaseName() + "@2").child("betadir").getRemote() + "!", j.buildAndAssertSuccess(p));
         });


### PR DESCRIPTION
[JENKINS-70528](https://issues.jenkins.io/browse/JENKINS-70528)

https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/291#issuecomment-1432225010 subsuming #293