### PR TITLE
Moving `PushdStep` here from `workflow-basic-steps`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/PushdStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/PushdStep.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import java.util.Set;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Temporarily changes the working directory.
+ */
+public class PushdStep extends Step {
+
+    private final String path;
+
+    @DataBoundConstructor public PushdStep(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Override public StepExecution start(StepContext context) throws Exception {
+        return new Execution(path, context);
+    }
+
+    @Extension(ordinal = 100) public static final class DescriptorImpl extends StepDescriptor {
+
+        @Override public String getFunctionName() {
+            return "dir";
+        }
+
+        @NonNull
+        @Override public String getDisplayName() {
+            return "Change current directory";
+        }
+
+        @Override public boolean takesImplicitBlockArgument() {
+            return true;
+        }
+
+        @Override public Set<? extends Class<?>> getRequiredContext() {
+            return Set.of(TaskListener.class, FilePath.class);
+        }
+        
+        @Override public Set<? extends Class<?>> getProvidedContext() {
+            return Set.of(FilePath.class);
+        }
+
+    }
+
+    public static class Execution extends StepExecution {
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final String path;
+
+        Execution(String path, StepContext context) {
+            super(context);
+            this.path = path;
+        }
+
+        @Override public boolean start() throws Exception {
+            FilePath dir = getContext().get(FilePath.class).child(path);
+            getContext().get(TaskListener.class).getLogger().println("Running in " + dir);
+            getContext().newBodyInvoker()
+                .withContext(FilePathDynamicContext.createContextualObject(dir))
+                // Could use a dedicated BodyExecutionCallback here if we wished to print a message at the end ("Returning to ${cwd}"):
+                .withCallback(BodyExecutionCallback.wrap(getContext()))
+                .start();
+            return false;
+        }
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2014 Jesse Glick.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="path" title="Path">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/help-path.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/help-path.html
@@ -1,0 +1,3 @@
+<div>
+    The relative path of the directory in the workspace to use as a new working directory.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/PushdStep/help.html
@@ -1,0 +1,4 @@
+<div>
+    Change current directory. Any step inside the <code>dir</code> block will 
+    use this directory as current and any relative path will use it as base path.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/PushdStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/PushdStepTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import hudson.FilePath;
+import hudson.slaves.DumbSlave;
+import java.util.logging.Level;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import static org.junit.Assert.assertNotNull;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+public class PushdStepTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
+    @Rule public LoggerRule logging = new LoggerRule().record(FilePathDynamicContext.class, Level.FINE);
+
+    @Test public void basics() throws Throwable {
+        sessions.then(j -> {
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node {dir('subdir') {echo(/now the pwd=${pwd()}/)}}", true));
+            j.assertLogContains("now the pwd=" + j.jenkins.getWorkspaceFor(p).child("subdir"), j.buildAndAssertSuccess(p));
+        });
+    }
+
+    @Test public void restarting() throws Throwable {
+        sessions.then(j -> {
+            j.createSlave("remote", null, null);
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node('remote') {dir('subdir') {semaphore 'restarting'; echo(/now the pwd=${pwd()}/)}}", true));
+            WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
+            SemaphoreStep.waitForStart("restarting/1", b);
+        });
+        sessions.then(j -> {
+            SemaphoreStep.success("restarting/1", null);
+            WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getLastBuild();
+            DumbSlave agent = (DumbSlave) j.jenkins.getNode("remote");
+            assertNotNull(agent);
+            j.waitOnline(agent);
+            FilePath ws = agent.getWorkspaceFor(p);
+            assertNotNull(ws);
+            j.assertLogContains("now the pwd=" + ws.child("subdir"), j.assertBuildStatusSuccess(j.waitForCompletion(b)));
+        });
+    }
+
+}


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/86#discussion_r289906309 https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/291#issuecomment-1432225010

Testing:
* Run 2.387 on a fresh userdir. Install `workflow-{job,cps,basic-steps,durable-task-step` and `pipeline-input-step`. Configure and start a project
```groovy
node {
    sh 'pwd'
    dir('subdir') {
        sh 'pwd'
        input 'proceed?'
        sh 'pwd'
    }
    sh 'pwd'
}
```
* Install a snapshot build of this PR and restart.
* Confirm that the running build is still running.
* Run another project and confirm that it works, though `DSL` prints a warning:
```groovy
node {
    sh 'pwd'
    dir('foo') {
        sh 'pwd'
    }
    sh 'pwd'
}
```
* Check **Pipeline Syntax** to see that `dir` is offered, once, and the help button indicates that it comes from this plugin.
* Install a snapshot build of https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/258 and restart.
* Approve the running build and confirm that it prints the expected paths.
* Run the second project. No warning this time.
* **Pipeline Syntax** looks the same.