### PR TITLE
[JENKINS-41219] Do not refer to now-removed `concurrency` param to `stage`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/help-dir.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/WorkspaceStep/help-dir.html
@@ -12,7 +12,7 @@
     If concurrent builds ask for the same workspace, a directory with a suffix such as <code>@2</code> may be locked instead.
     Currently there is no option to wait to lock the exact directory requested;
     if you need to enforce that behavior, you can either fail (<code>error</code>) when <code>pwd</code> indicates that you got a different directory,
-    or you may enforce serial execution of this part of the build by some other means such as <code>stage name: '…', concurrency: 1</code>.
+    or you may enforce serial execution of this part of the build by some other means such as the <code>lock</code> step.
 </p>
 <p>
     If you do not care about locking, just use the <code>dir</code> step to change current directory.


### PR DESCRIPTION
[JENKINS-41219](https://issues.jenkins.io/browse/JENKINS-41219) especially after https://github.com/jenkinsci/pipeline-stage-step-plugin/pull/94.