### PR TITLE
Trying to deflake `ExecutorStepTest.queueItemAction`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,5 +159,17 @@
             <version>1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -80,6 +80,7 @@ import net.sf.json.JSONObject;
 import net.sf.json.groovy.JsonSlurper;
 import org.acegisecurity.Authentication;
 import org.apache.commons.io.IOUtils;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.*;
 import org.jenkinsci.plugins.durabletask.FileMonitoringTask;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
@@ -604,8 +605,7 @@ public class ExecutorStepTest {
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 r.waitForMessage("[Pipeline] node", b);
 
-                FlowNode executorStartNode = new DepthFirstScanner().findFirstMatch(b.getExecution(), new ExecutorStepWithQueueItemPredicate());
-                assertNotNull(executorStartNode);
+                FlowNode executorStartNode = await().until(() -> new DepthFirstScanner().findFirstMatch(b.getExecution(), new ExecutorStepWithQueueItemPredicate()), notNullValue());
 
                 assertNotNull(executorStartNode.getAction(QueueItemAction.class));
                 assertEquals(QueueItemAction.QueueState.QUEUED, QueueItemAction.getNodeState(executorStartNode));


### PR DESCRIPTION
Not locally reproducible, but have observed in PCT

```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertNotNull(Assert.java:713)
	at org.junit.Assert.assertNotNull(Assert.java:723)
	at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepTest.lambda$queueItemAction$20(ExecutorStepTest.java:608)
```

I am guessing this is some sort of race condition, in which case waiting a bit might help.
