### PR TITLE
[JENKINS-52165] Stabilize and better test `USE_WATCHING`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
     [platform: 'linux', jdk: 17],
     [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,20 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <version>2081.v85885a_d2e5c5</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- TODO until in BOM -->
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>durable-task</artifactId>
+                <version>510.v324450f8dca_4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-api</artifactId>
+                <version>1232.v1679fa_2f0f76</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,12 +86,12 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>durable-task</artifactId>
-                <version>512.vb_fa_f04b_09178</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/186 -->
+                <version>513.vc48a_a_075a_d93</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1247.v12f6b_094cea_d</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
+                <version>1248.v4b_91043341d2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,12 +86,12 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>durable-task</artifactId>
-                <version>510.v324450f8dca_4</version>
+                <version>512.vb_fa_f04b_09178</version> <!-- TODO https://github.com/jenkinsci/durable-task-plugin/pull/186 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1246.v59f1a_f2e70ca_</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
+                <version>1247.v12f6b_094cea_d</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
+        <jenkins-test-harness.version>2040.v39c760a_432f9</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/621 -->
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
@@ -89,7 +90,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1232.v1679fa_2f0f76</version>
+                <version>1233.vc57a_f92b_a_278</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1243.v14eedc2295ed</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
+                <version>1246.v59f1a_f2e70ca_</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1233.vc57a_f92b_a_278</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
+                <version>1235.v9b_7f964a_a_d70</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
                 <artifactId>workflow-api</artifactId>
                 <version>1246.v59f1a_f2e70ca_</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials-binding</artifactId>
+                <version>621.v58c0fb_d285a_c</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
-        <jenkins-test-harness.version>2040.v39c760a_432f9</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/621 -->
+        <!-- TODO until in plugin-pom -->
+        <jenkins-test-harness.version>2042.v787a_641a_9b_26</jenkins-test-harness.version>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
@@ -90,7 +91,7 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>1235.v9b_7f964a_a_d70</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
+                <version>1243.v14eedc2295ed</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/294 -->
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -444,13 +444,12 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
         /**
          * Interprets {@link OutputStream#close} as a signal to end a final newline if necessary.
          */
-        private static final class NewlineSafeTaskListener implements OutputStreamTaskListener {
+        private static final class NewlineSafeTaskListener extends OutputStreamTaskListener.Default {
 
             private static final long serialVersionUID = 1;
 
             private final TaskListener delegate;
             private transient OutputStream out;
-            private transient PrintStream logger;
 
             NewlineSafeTaskListener(TaskListener delegate) {
                 this.delegate = delegate;
@@ -484,14 +483,6 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                     };
                 }
                 return out;
-            }
-
-            @NonNull
-            @Override public synchronized PrintStream getLogger() {
-                if (logger == null) {
-                    logger = new PrintStream(getOutputStream(), false, StandardCharsets.UTF_8);
-                }
-                return logger;
             }
 
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -64,6 +64,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.tasks.filters.EnvVarsFilterableBuilder;
+import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -203,7 +204,7 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
     /** If set to false, disables {@link Execution#watching} mode. */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable only for tests")
     @Restricted(NoExternalUse.class)
-    public static boolean USE_WATCHING = Boolean.getBoolean(DurableTaskStep.class.getName() + ".USE_WATCHING"); // JENKINS-52165: turn back on by default
+    public static boolean USE_WATCHING = SystemProperties.getBoolean(DurableTaskStep.class.getName() + ".USE_WATCHING", true);
 
     /** How many seconds to wait before interrupting remote calls and before forcing cleanup when the step is stopped */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable for script console access")

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -55,8 +55,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -79,6 +77,7 @@ import org.jenkinsci.plugins.workflow.FilePathUtils;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.log.OutputStreamTaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -443,13 +442,14 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
         }
 
         /**
-         * Interprets {@link PrintStream#close} as a signal to end a final newline if necessary.
+         * Interprets {@link OutputStream#close} as a signal to end a final newline if necessary.
          */
-        private static final class NewlineSafeTaskListener implements TaskListener {
+        private static final class NewlineSafeTaskListener implements OutputStreamTaskListener {
 
             private static final long serialVersionUID = 1;
 
             private final TaskListener delegate;
+            private transient OutputStream out;
             private transient PrintStream logger;
 
             NewlineSafeTaskListener(TaskListener delegate) {
@@ -457,12 +457,9 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
             }
 
             // Similar to DecoratedTaskListener:
-            @NonNull
-            @Override public synchronized PrintStream getLogger() {
-                if (logger == null) {
-                    LOGGER.fine("creating filtered stream");
-                    OutputStream base = delegate.getLogger();
-                    OutputStream filtered = new FilterOutputStream(base) {
+            @Override public synchronized OutputStream getOutputStream() {
+                if (out == null) {
+                    out = new FilterOutputStream(OutputStreamTaskListener.getOutputStream(delegate)) {
                         boolean nl = true; // empty string does not need a newline
                         @Override public void write(int b) throws IOException {
                             super.write(b);
@@ -481,12 +478,18 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                             }
                             flush(); // do *not* call base.close() here, unlike super.close()
                         }
+                        @Override public String toString() {
+                            return "NewlineSafeTaskListener.output[" + out + "]";
+                        }
                     };
-                    try {
-                        logger = new PrintStream(filtered, false, "UTF-8");
-                    } catch (UnsupportedEncodingException x) {
-                        throw new AssertionError(x);
-                    }
+                }
+                return out;
+            }
+
+            @NonNull
+            @Override public synchronized PrintStream getLogger() {
+                if (logger == null) {
+                    logger = new PrintStream(getOutputStream(), false, StandardCharsets.UTF_8);
                 }
                 return logger;
             }
@@ -703,21 +706,6 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
 
     private static class HandlerImpl extends Handler {
 
-        private static final Field printStreamDelegate;
-        static {
-            try {
-                printStreamDelegate = FilterOutputStream.class.getDeclaredField("out");
-            } catch (NoSuchFieldException x) {
-                // Defined in Java Platform and protected, so should not happen.
-                throw new ExceptionInInitializerError(x);
-            }
-            try {
-                printStreamDelegate.setAccessible(true);
-            } catch (/* TODO Java 11+ InaccessibleObjectException */RuntimeException x) {
-                LOGGER.log(Level.WARNING, "On Java 17 error handling is degraded unless `--add-opens java.base/java.io=ALL-UNNAMED` is passed to the agent", x);
-            }
-        }
-
         private static final long serialVersionUID = 1L;
 
         private final ExecutionRemotable execution;
@@ -730,34 +718,24 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
 
         @Override public void output(@NonNull InputStream stream) throws Exception {
             PrintStream ps = listener.getLogger();
+            OutputStream os = OutputStreamTaskListener.getOutputStream(listener);
             try {
-                if (ps.getClass() == PrintStream.class) {
-                    // Try to extract the underlying stream, since swallowing exceptions is undesirable and PrintStream.checkError is useless.
-                    OutputStream os = ps;
-                    try {
-                        os = (OutputStream) printStreamDelegate.get(ps);
-                    } catch (IllegalAccessException x) {
-                        LOGGER.log(Level.FINE, "using PrintStream rather than underlying FilterOutputStream.out", x);
-                    }
-                    if (os == null) { // like PrintStream.ensureOpen
-                        throw new IOException("Stream closed");
-                    }
-                    synchronized (ps) { // like PrintStream.write overloads do
-                        IOUtils.copy(stream, os);
-                    }
-                } else {
-                    // A subclass. Who knows why, but trust any write(…) overrides it may have.
-                    IOUtils.copy(stream, ps);
+                synchronized (ps) { // like PrintStream.write overloads do
+                    IOUtils.copy(stream, os);
                 }
+                LOGGER.finest(() -> "print to " + os + " succeeded");
             } catch (ChannelClosedException x) {
+                LOGGER.log(Level.FINE, null, x);
                 // We are giving up on this watch. Wait for some call to getWorkspace to rewatch.
                 throw x;
             } catch (Exception x) {
+                LOGGER.log(Level.FINE, null, x);
                 // Try to report it to the controller.
                 try {
                     execution.problem(x);
                     // OK, printed to log on controller side, we may have lost some text but could continue.
                 } catch (Exception x2) { // e.g., RemotingSystemException
+                    LOGGER.log(Level.FINE, null, x2);
                     // No, channel seems to be broken, give up on this watch.
                     throw x;
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -66,7 +66,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.tasks.filters.EnvVarsFilterableBuilder;
-import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -208,7 +207,7 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
     /** If set to false, disables {@link Execution#watching} mode. */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable only for tests")
     @Restricted(NoExternalUse.class)
-    public static boolean USE_WATCHING = SystemProperties.getBoolean(DurableTaskStep.class.getName() + ".USE_WATCHING", true);
+    public static boolean USE_WATCHING = Boolean.getBoolean(DurableTaskStep.class.getName() + ".USE_WATCHING"); // JENKINS-52165: turn back on by default
 
     /** How many seconds to wait before interrupting remote calls and before forcing cleanup when the step is stopped */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "public & mutable for script console access")

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -658,11 +658,11 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                 getContext().onSuccess(returnStatus ? exitCode : returnStdout ? new String(output.produce(), StandardCharsets.UTF_8) : null);
             } else {
                 if (returnStdout) {
-                    listener().getLogger().write(output.produce()); // diagnostic
+                    _listener().getLogger().write(output.produce()); // diagnostic
                 }
                 if (originalCause != null) {
                     // JENKINS-28822: Use the previous cause instead of throwing a new AbortException
-                    listener().getLogger().println("script returned exit code " + exitCode);
+                    _listener().getLogger().println("script returned exit code " + exitCode);
                     getContext().onFailure(originalCause);
                 } else {
                     getContext().onFailure(new AbortException("script returned exit code " + exitCode));

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -781,8 +781,8 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
             String name = c.getName();
             StepExecution.applyAll(Execution.class, exec -> {
                 if (exec.watching && exec.node.equals(name)) {
-                    LOGGER.fine(() -> "Online/offline event on " + name + ", checking current status of " + exec.remote + " immediately");
-                    threadPool().schedule(exec, 1, TimeUnit.SECONDS);
+                    LOGGER.fine(() -> "Online/offline event on " + name + ", checking current status of " + exec.remote + " shortly");
+                    threadPool().schedule(exec::check, 1, TimeUnit.SECONDS);
                 }
                 return null;
             });

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/AgentErrorCondition.java
@@ -61,7 +61,7 @@ public final class AgentErrorCondition extends ErrorCondition {
                 c -> c instanceof ExecutorStepExecution.RemovedNodeCause || c instanceof ExecutorStepExecution.QueueTaskCancelled)) {
             return true;
         }
-        if (isClosedChannel(t)) {
+        if (isClosedChannelException(t)) {
             return true;
         }
         if (t instanceof MissingContextVariableException) {
@@ -75,7 +75,8 @@ public final class AgentErrorCondition extends ErrorCondition {
         return false;
     }
 
-    private static boolean isClosedChannel(Throwable t) {
+    // TODO https://github.com/jenkinsci/remoting/pull/657
+    private static boolean isClosedChannelException(Throwable t) {
         if (t instanceof ClosedChannelException) {
             return true;
         } else if (t instanceof ChannelClosedException) {
@@ -85,7 +86,7 @@ public final class AgentErrorCondition extends ErrorCondition {
         } else if (t == null) {
             return false;
         } else {
-            return isClosedChannel(t.getCause()) || Stream.of(t.getSuppressed()).anyMatch(AgentErrorCondition::isClosedChannel);
+            return isClosedChannelException(t.getCause()) || Stream.of(t.getSuppressed()).anyMatch(AgentErrorCondition::isClosedChannelException);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps.durable_task;
+
+import hudson.Functions;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.awaitility.Awaitility.await;
+import org.jenkinsci.plugins.durabletask.FileMonitoringTask;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.InboundAgentRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.PrefixedOutputStream;
+import org.jvnet.hudson.test.RealJenkinsRule;
+import org.jvnet.hudson.test.TailLog;
+
+public final class RealShellStepTest {
+
+    private static final Logger LOGGER = Logger.getLogger(RealShellStepTest.class.getName());
+
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule().
+        withColor(PrefixedOutputStream.Color.BLUE).
+        withLogger(DurableTaskStep.class, Level.FINE).
+        withLogger(FileMonitoringTask.class, Level.FINE);
+
+    @Rule public InboundAgentRule inboundAgents = new InboundAgentRule();
+
+    @Test public void shellScriptExitingAcrossRestart() throws Throwable {
+        Assume.assumeFalse("TODO translate to batch script", Functions.isWindows());
+        rr.startJenkins();
+        inboundAgents.createAgent(rr, InboundAgentRule.Options.newBuilder().color(PrefixedOutputStream.Color.MAGENTA).label("remote").build());
+        try (var tailLog = new TailLog(rr, "p", 1).withColor(PrefixedOutputStream.Color.YELLOW)) {
+            rr.runRemotely(RealShellStepTest::shellScriptExitingAcrossRestart1);
+            rr.stopJenkins();
+            var f = new File(rr.getHome(), "f");
+            LOGGER.info(() -> "Waiting for " + f + " to be written…");
+            await().until(f::isFile);
+            LOGGER.info("…done.");
+            rr.startJenkins();
+            rr.runRemotely(RealShellStepTest::shellScriptExitingAcrossRestart2);
+            tailLog.waitForCompletion();
+        }
+    }
+    private static void shellScriptExitingAcrossRestart1(JenkinsRule r) throws Throwable {
+        var p = r.createProject(WorkflowJob.class, "p");
+        var f = new File(r.jenkins.getRootDir(), "f");
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("F")));
+        p.setDefinition(new CpsFlowDefinition("node('remote') {sh 'sleep 5 && touch \"$F\"'}", true));
+        var b = p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("F", f.getAbsolutePath()))).waitForStart();
+        r.waitForMessage("+ sleep 5", b);
+        r.jenkins.doQuietDown(true, 0, null);
+    }
+    private static void shellScriptExitingAcrossRestart2(JenkinsRule r) throws Throwable {
+        var p = (WorkflowJob) r.jenkins.getItem("p");
+        var b = p.getLastBuild();
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        r.assertLogContains("+ touch " + new File(r.jenkins.getRootDir(), "f"), b);
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
@@ -33,6 +33,7 @@ import hudson.model.StringParameterValue;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.ComputerListener;
 import java.io.File;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.slaves.restarter.JnlpSlaveRestarterInstaller;
@@ -44,13 +45,22 @@ import org.jenkinsci.plugins.workflow.log.FileLogStorage;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.InboundAgentRule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.PrefixedOutputStream;
 import org.jvnet.hudson.test.RealJenkinsRule;
 import org.jvnet.hudson.test.TailLog;
 
+@RunWith(Parameterized.class)
 public final class RealShellStepTest {
+
+    @Parameterized.Parameters(name = "watching={0}") public static List<Boolean> data() {
+        return List.of(false, true);
+    }
+
+    @Parameterized.Parameter public boolean useWatching;
 
     private static final Logger LOGGER = Logger.getLogger(RealShellStepTest.class.getName());
 
@@ -62,6 +72,7 @@ public final class RealShellStepTest {
     @Rule public InboundAgentRule inboundAgents = new InboundAgentRule();
 
     @Test public void shellScriptExitingAcrossRestart() throws Throwable {
+        rr.javaOptions("-D" + DurableTaskStep.class.getName() + ".USE_WATCHING=" + useWatching);
         Assume.assumeFalse("TODO translate to batch script", Functions.isWindows());
         rr.startJenkins();
         rr.runRemotely(RealShellStepTest::disableJnlpSlaveRestarterInstaller);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/RealShellStepTest.java
@@ -85,7 +85,9 @@ public final class RealShellStepTest {
         var p = (WorkflowJob) r.jenkins.getItem("p");
         var b = p.getLastBuild();
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        /* TODO this late output is sometimes lost:
         r.assertLogContains("+ touch " + new File(r.jenkins.getRootDir(), "f"), b);
+        */
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -42,7 +42,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
@@ -443,14 +442,13 @@ public class ShellStepTest {
             };
         }
     }
-    private static class RemotableBuildListener implements BuildListener, OutputStreamTaskListener {
+    private static class RemotableBuildListener extends OutputStreamTaskListener.Default implements BuildListener {
         private static final long serialVersionUID = 1;
         /** actual implementation */
         private final TaskListener delegate;
         /** records allocation & deserialization history; e.g., {@code master → agent} */
         private final String id;
         private transient OutputStream out;
-        private transient PrintStream logger;
         RemotableBuildListener(TaskListener delegate) {
             this(delegate, "master");
         }
@@ -480,13 +478,6 @@ public class ShellStepTest {
                 };
             }
             return out;
-        }
-        @NonNull
-        @Override public PrintStream getLogger() {
-            if (logger == null) {
-                logger = new PrintStream(getOutputStream(), true, StandardCharsets.UTF_8);
-            }
-            return logger;
         }
         private Object writeReplace() {
             /* To see serialization happening from BourneShellScript.launchWithCookie & FileMonitoringController.watch:


### PR DESCRIPTION
[JENKINS-52165](https://issues.jenkins.io/browse/JENKINS-52165): the performance benefits seem important. Have not yet tried to measure impact on (controller) CPU or Remoting channel bandwidth, but can use inotify to verify this allows a long-running `sh` step with copious output to only write to `log` (and maybe `log-index`), whereas in currently default pull mode there are constant writes to `program.dat` (via an atomic temp file) due to https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/6f24fa9eb65bc86c5d34718990f90db968f0003e/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L599-L601 which would otherwise be limited to step transitions.

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/294 and https://github.com/jenkinsci/durable-task-plugin/pull/186.

- [x] test failures
- [x] pick up https://github.com/jenkinsci/workflow-api-plugin/pull/290 & https://github.com/jenkinsci/durable-task-plugin/pull/185
- [x] handle #212 more cleanly
- [x] check PCT (https://github.com/jenkinsci/bom/pull/2246 and CloudBees CI)
- [x] log output sometimes lost across restarts (caught in CloudBees CI proprietary tests)
- [x] test against `pipeline-cloudwatch-logs`
- [x] test against `KubernetesPipelineOverridenNamespaceTest`
- [x] parameterize relevant tests to run with and without watching mode
- [X] https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/323#issuecomment-1650618648
- [x] have at least some Windows test coverage
- [x] try https://github.com/jenkins-infra/pipeline-library/pull/707