### PR TITLE
Remove outdated Jenkins version test conditional

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -772,9 +772,10 @@ public class ExecutorStepTest {
     @Issue("JENKINS-36547")
     @Test public void reuseNodesWithSameLabelsInDifferentReorderedStages() throws Throwable {
         sessions.then(r -> {
-            // Note: for Jenkins versions > 2.65, the number of agents must be increased to 5.
+            // Note: for Jenkins versions > 2.265, the number of agents must be 5.
+            // Older Jenkins versions used 3 agents.
             // This is due to changes in the Load Balancer (See JENKINS-60563).
-            int totalAgents = Jenkins.getVersion().isNewerThan(new VersionNumber("2.265")) ? 5 : 3;
+            int totalAgents = 5;
             createNOnlineAgentWithLabels(r, totalAgents, "foo bar");
 
             WorkflowJob p = r.createProject(WorkflowJob.class, "demo");


### PR DESCRIPTION
## Remove outdated test conditional for Jenkins version

The plugin no longer supports Jenkins versions as old as 2.265, so the conditional will always evaluate to true.

### Testing done

Automated tests pass on Linux with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
