### PR TITLE
Do not even try to use `LogTaskListener`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -47,7 +47,6 @@ import hudson.slaves.ComputerListener;
 import hudson.slaves.OfflineCause;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.FormValidation;
-import hudson.util.LogTaskListener;
 import hudson.util.NamingThreadFactory;
 import hudson.util.StreamTaskListener;
 import java.io.FilterOutputStream;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -430,11 +430,11 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                     LOGGER.log(Level.FINEST, "JENKINS-34021: DurableTaskStep.Execution.listener present in {0}", context);
                 } else {
                     LOGGER.log(Level.WARNING, "JENKINS-34021: TaskListener not available upon request in {0}", context);
-                    l = new LogTaskListener(LOGGER, Level.FINE);
+                    l = TaskListener.NULL;
                 }
             } catch (Exception x) {
                 LOGGER.log(Level.FINE, "JENKINS-34021: could not get TaskListener in " + context, x);
-                l = new LogTaskListener(LOGGER, Level.FINE);
+                l = TaskListener.NULL;
                 recurrencePeriod = 0;
             }
             return l;


### PR DESCRIPTION
Likely pointless to even try to record `sh` step output when the build is so broken that `TaskListener` is not available from the `StepContext`! See https://github.com/jenkinsci/workflow-api-plugin/pull/298.