### PR TITLE
`build` attribute for `buildProgressBar` should be a `Queue.Executable`, not a `Queue.Task`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -942,7 +942,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
          * Occupies {@link Executor} while workflow uses this build agent.
          */
         @ExportedBean
-        private final class PlaceholderExecutable implements ContinuableExecutable, AccessControlled {
+        @Restricted(NoExternalUse.class) // Class must be public for Jelly.
+        public final class PlaceholderExecutable implements ContinuableExecutable, AccessControlled {
 
             @Override public void run() {
                 TaskListener listener = null;

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution/PlaceholderTask/PlaceholderExecutable/executorCell.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution/PlaceholderTask/PlaceholderExecutable/executorCell.jelly
@@ -32,7 +32,7 @@
             <j:choose>
                 <j:when test="${rAuth != null}">
                     <a href="${rootURL}/${r.parent.url}"><l:breakable value="${r.parent.fullDisplayName}"/></a>
-                    <t:buildProgressBar build="${it.parent}" executor="${executor}"/>
+                    <t:buildProgressBar build="${it}" executor="${executor}"/>
                 </j:when>
                 <j:otherwise>
                     <span>${%Unknown Pipeline node step}</span>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/blob/4c5e4f86d1fb3bce5d027446e12259c7edcac27f/core/src/main/resources/lib/hudson/buildProgressBar.jelly#L29.

In practice this did not matter because the Jelly template only ever used `build.url` in this case, which is the same between `PlaceholderTask` and `PlaceholderExecutable`, but it causes problems with some changes I am proposing upstream in https://github.com/jenkinsci/jenkins/pull/8321 where we actually need to find the associated `Run`, see [this comment]( https://github.com/jenkinsci/jenkins/pull/8321/files#r1289340587) in particular.

<!-- Please describe your pull request here. -->

### Testing done

Tested manually.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
