### PR TITLE
`lastLocation` testing

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -349,8 +349,10 @@ public class ExecutorStepTest {
         sessions.then(r -> {
                 logging.record(DurableTaskStep.class, Level.FINE).
                         record(ExecutorStepDynamicContext.class, Level.FINE).
+                        record(FileMonitoringTask.class, Level.FINEST).
                         record(WorkspaceList.class, Level.FINE);
                 Slave s = inboundAgents.createAgent(r, "dumbo");
+                r.showAgentLogs(s, logging);
                 WorkflowJob p = r.createProject(WorkflowJob.class, "demo");
                 File f1 = new File(r.jenkins.getRootDir(), "f1");
                 File f2 = new File(r.jenkins.getRootDir(), "f2");
@@ -398,6 +400,7 @@ public class ExecutorStepTest {
                     Thread.sleep(100);
                 }
                 LOGGER.info("agent back online");
+                r.showAgentLogs(s, logging);
                 assertWorkspaceLocked(computer, workspacePath);
                 assertTrue(f2.isFile());
                 assertTrue(f1.delete());


### PR DESCRIPTION
Pairs with https://github.com/jenkinsci/durable-task-plugin/pull/187. I noticed a flake in `ExecutorStepTest.contextualizeFreshFilePathAfterAgentReconnection[watching=true]`: the test timed out, and the log included

```
WARNING: org.jenkinsci.plugins.durabletask.FileMonitoringTask$Watcher@… giving up on watching …/dumbo/workspace/demo@tmp/durable-…
java.lang.NumberFormatException: For input string: ""
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Long.parseLong(Long.java:702)
	at java.base/java.lang.Long.parseLong(Long.java:817)
	at org.jenkinsci.plugins.durabletask.FileMonitoringTask$Watcher.run(FileMonitoringTask.java:622)
```

I do not have a clear hypothesis as to why `lastLocation` was empty; perhaps a half-written file could be to blame, in which case using `AtomicFileWriter` could help, but this seems dubious when the same process should have already finished writing the same file.
