### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,12 @@
-buildPlugin(useContainerAgent: true, forkCount: '1C', configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+/*
+ See the documentation for more options:
+
+https://github.com/jenkins-infra/pipeline-library/
+
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  forkCount: '1C', 
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],


### PR DESCRIPTION
Test with Java 21
==

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21