### PR TITLE
Fine logging with stack trace when queue item cancelled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -252,6 +252,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 if (li.task instanceof PlaceholderTask) {
                     PlaceholderTask task = (PlaceholderTask) li.task;
                     if (!task.stopping) {
+                        if (LOGGER.isLoggable(Level.FINE)) {
+                            LOGGER.log(Level.FINE, null, new Throwable(li.task + " was cancelled"));
+                        }
                         task.context.onFailure(new FlowInterruptedException(Result.ABORTED, true, new QueueTaskCancelled()));
                     }
                 }


### PR DESCRIPTION
Hoping to track down a test failure in @cloudbees which shows a build being aborted with `QueueTaskCancelled` but not why. The other plausible path is https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/68be217043e3a52a25254c3c433f71e601f043f3/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java#L113-L115 which already does fine logging.