### PR TITLE
Simplified `PlaceholderTask`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -114,11 +114,10 @@ public class ExecutorPickle extends Pickle {
                     if (task instanceof ExecutorStepExecution.PlaceholderTask) {
                         ExecutorStepExecution.PlaceholderTask placeholder = (ExecutorStepExecution.PlaceholderTask)task;
 
-                        // Non-null cookie means body has begun execution, i.e. we started using a node
                         // PlaceholderTask#getAssignedLabel is set to the Node name when execution starts
                         // Thus we're guaranteeing the execution began and the Node is now unknown.
                         // Theoretically it's safe to simply fail earlier when rehydrating any EphemeralNode... but we're being extra safe.
-                        if (placeholder.getCookie() != null && Jenkins.get().getNode(placeholder.getAssignedLabel().getName()) == null ) {
+                        if (placeholder.hasStarted() && Jenkins.get().getNode(placeholder.getAssignedLabel().getName()) == null ) {
                             if (System.nanoTime() > endTimeNanos) {
                                 Queue.getInstance().cancel(item);
                                 owner.getListener().getLogger().printf("Killed %s after waiting for %s because we assume unknown agent %s is never going to appear%n",

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -69,7 +69,7 @@ public final class ExecutorStepDynamicContext implements Serializable {
 
     private static final long serialVersionUID = 1;
 
-    @NonNull ExecutorStepExecution.PlaceholderTask task;
+    final @NonNull ExecutorStepExecution.PlaceholderTask task;
     final @NonNull String node;
     final @NonNull String path;
     final int depth;
@@ -97,8 +97,6 @@ public final class ExecutorStepDynamicContext implements Serializable {
         if (item == null) {
             throw new IllegalStateException("queue refused " + task);
         }
-        // Try to avoid having distinct a instance of PlaceholderTask here compared to any previously-scheduled task.
-        task = (ExecutorStepExecution.PlaceholderTask)item.task;
         LOGGER.fine(() -> (result.isCreated() ? "scheduled " : " using already-scheduled ") + item + " for " + path + " on " + node);
         TaskListener listener = context.get(TaskListener.class);
         if (!node.isEmpty()) { // unlikely to be any delay for built-in node anyway

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -164,7 +164,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             if (item.task instanceof PlaceholderTask) {
                 PlaceholderTask task = (PlaceholderTask) item.task;
                 if (task.context.equals(context)) {
-                    task.stopping = true;
+                    RunningTasks.run(context, t -> t.stopping = true);
                     if (Queue.getInstance().cancel(item)) {
                         LOGGER.fine(() -> "canceled " + item);
                     } else {
@@ -188,7 +188,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     if (exec instanceof PlaceholderTask.PlaceholderExecutable) {
                         StepContext actualContext = ((PlaceholderTask.PlaceholderExecutable) exec).getParent().context;
                         if (actualContext.equals(context)) {
-                            PlaceholderTask.finish(((PlaceholderTask.PlaceholderExecutable) exec).getParent().cookie);
+                            PlaceholderTask.finish(context, ((PlaceholderTask.PlaceholderExecutable) exec).getParent().cookie);
                             LOGGER.log(FINE, "canceling {0}", exec);
                             break COMPUTERS;
                         } else {
@@ -251,7 +251,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             if (li.isCancelled()) {
                 if (li.task instanceof PlaceholderTask) {
                     PlaceholderTask task = (PlaceholderTask) li.task;
-                    if (!task.stopping) {
+                    if (!RunningTasks.get(task.context, t -> t.stopping)) {
                         if (LOGGER.isLoggable(Level.FINE)) {
                             LOGGER.log(Level.FINE, null, new Throwable(li.task + " was cancelled"));
                         }
@@ -395,6 +395,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         @Nullable AsynchronousExecution execution;
         /** null until placeholder executable runs */
         @Nullable Launcher launcher;
+        /**
+         * Flag to remember that {@link #stop} is being called, so {@link CancelledItemListener} can be suppressed.
+         * Also used for {@link PlaceholderTask#getCauseOfBlockage}.
+         */
+        boolean stopping;
     }
 
     private static final String COOKIE_VAR = "JENKINS_NODE_COOKIE";
@@ -408,18 +413,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         private final String runId;
         /**
          * Unique cookie set once the task starts.
-         * Serves multiple purposes:
-         * identifies whether we have already invoked the body (since this can be rerun after restart);
-         * serves as a key for {@link RunningTasks#runningTasks} and {@link Callback} (cannot just have a doneness flag in {@link PlaceholderTask} because multiple copies might be deserialized);
-         * and allows {@link Launcher#kill} to work.
+         * Allows {@link Launcher#kill} to work.
          */
         private String cookie;
 
         /** {@link Authentication#getName} of user of build, if known. */
         private final @CheckForNull String auth;
-
-        /** Flag to remember that {@link #stop} is being called, so {@link CancelledItemListener} can be suppressed. */
-        private transient boolean stopping;
 
         PlaceholderTask(StepContext context, String label) throws IOException, InterruptedException {
             this.context = context;
@@ -432,27 +431,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 auth = runningAuth.getName();
             }
             LOGGER.log(FINE, "scheduling {0}", this);
-        }
-
-        private Object readResolve() {
-            if (cookie != null) {
-                RunningTasks.get().withRunningTasks(runningTasks -> {
-                    // If Jenkins stops while this step is resuming, there may be a PlaceholderTask in the queue as
-                    // well as in program.dat for the same step. We want to make sure not to create a second task to
-                    // avoid race conditions, so we use putIfAbsent.
-                    // TODO: This helps for runningTasks, but other fields like `stopping` may still be problematic.
-                    // Should we refactor things to guarantee that the relevant state is a singleton? For example,
-                    // introduce a PlaceholderTasksAction that holds a map of a new PlaceholderTaskState class, which
-                    // would hold most of what is currently in PlaceholderTask, and then PlaceholderTask would only
-                    // hold a `String cookie` field and would look up PlaceholderTaskState via the action so it wouldn't
-                    // matter where the task was serialized.
-                    runningTasks.putIfAbsent(cookie, new RunningTask());
-                });
-            }
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(FINE, null, new Exception("deserializing previously scheduled " + this));
-            }
-            return this;
         }
 
         /**
@@ -492,9 +470,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return new PlaceholderExecutable();
         }
 
-        @CheckForNull
-        public String getCookie() {
-            return cookie;
+        /** Body has begun execution: we started using a node. */
+        @Restricted(NoExternalUse.class)
+        public boolean hasStarted() {
+            return cookie != null;
         }
 
         @Override public Label getAssignedLabel() {
@@ -533,6 +512,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public CauseOfBlockage getCauseOfBlockage() {
+            boolean stopping = RunningTasks.get(context, t -> t.stopping);
             if (FlowExecutionList.get().isResumptionComplete()) {
                 // We only do this if resumption is complete so that we do not load the run and resume its execution in this context in normal scenarios.
                 Run<?, ?> run = runForDisplay();
@@ -540,7 +520,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     if (stopping) {
                         LOGGER.warning(() -> "Refusing to build " + PlaceholderTask.this + " and going to cancel it, even though it was supposedly stopped already, because associated build is complete");
                     } else {
-                        stopping = true;
+                        RunningTasks.run(context, t -> t.stopping = true);
                     }
                     Timer.get().execute(() -> {
                         if (Queue.getInstance().cancel(this)) {
@@ -640,8 +620,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 }
                 return context.get(Run.class);
             } catch (Exception x) {
-                LOGGER.log(FINE, "broken " + cookie + " in " + runId, x);
-                finish(cookie); // probably broken, so just shut it down
+                LOGGER.log(FINE, "broken " + context, x);
+                finish(context, cookie); // probably broken, so just shut it down
                 return null;
             }
         }
@@ -875,7 +855,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         }
 
         @Override public String toString() {
-            return "ExecutorStepExecution.PlaceholderTask{runId=" + runId + ",label=" + label + ",context=" + context + ",cookie=" + cookie + ",auth=" + auth + '}';
+            return "ExecutorStepExecution.PlaceholderTask{label=" + label + ",context=" + context + '}';
         }
 
         @Override
@@ -896,34 +876,28 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             return this.context.equals(other.context);
         }
 
-        private static void finish(@CheckForNull final String cookie) {
-            if (cookie == null) {
+        private static void finish(StepContext context, @CheckForNull final String cookie) {
+            RunningTask runningTask = RunningTasks.remove(context);
+            final AsynchronousExecution execution = runningTask.execution;
+            if (execution == null) {
+                // JENKINS-30759: finished before asynch execution was even scheduled
                 return;
             }
-            RunningTasks.get().withRunningTasks(runningTasks -> {
-                final RunningTask runningTask = runningTasks.remove(cookie);
-                if (runningTask == null) {
-                    LOGGER.log(FINE, "no running task corresponds to {0}", cookie);
+            assert runningTask.launcher != null;
+            Timer.get().submit(() -> execution.completed(null)); // JENKINS-31614
+            Computer.threadPoolForRemoting.submit(() -> { // JENKINS-34542, JENKINS-45553
+                if (cookie == null) {
                     return;
                 }
-                final AsynchronousExecution execution = runningTask.execution;
-                if (execution == null) {
-                    // JENKINS-30759: finished before asynch execution was even scheduled
-                    return;
+                try {
+                    runningTask.launcher.kill(Collections.singletonMap(COOKIE_VAR, cookie));
+                } catch (ChannelClosedException x) {
+                    // fine, Jenkins was shutting down
+                } catch (RequestAbortedException x) {
+                    // agent was exiting; too late to kill subprocesses
+                } catch (Exception x) {
+                    LOGGER.log(Level.WARNING, "failed to shut down " + cookie + " from " + context, x);
                 }
-                assert runningTask.launcher != null;
-                Timer.get().submit(() -> execution.completed(null)); // JENKINS-31614
-                Computer.threadPoolForRemoting.submit(() -> { // JENKINS-34542, JENKINS-45553
-                    try {
-                        runningTask.launcher.kill(Collections.singletonMap(COOKIE_VAR, cookie));
-                    } catch (ChannelClosedException x) {
-                        // fine, Jenkins was shutting down
-                    } catch (RequestAbortedException x) {
-                        // agent was exiting; too late to kill subprocesses
-                    } catch (Exception x) {
-                        LOGGER.log(Level.WARNING, "failed to shut down " + cookie, x);
-                    }
-                });
             });
         }
 
@@ -946,32 +920,32 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
 
             @Override protected void finished(StepContext context) throws Exception {
-                LOGGER.log(FINE, "finished {0}", cookie);
+                if (execution == null) { // compatibility with old serial forms
+                    lease.release();
+                    lease = null;
+                    return;
+                }
+                LOGGER.log(FINE, "finished {0}", execution.getContext());
                 try {
-                    if (execution != null) {
-                        WorkspaceList.Lease _lease = ExtensionList.lookupSingleton(ExecutorStepDynamicContext.WorkspaceListLeaseTranslator.class).get(execution.state);
-                        if (_lease != null) {
-                            _lease.release();
-                        }
-                    } else {
-                        lease.release();
-                        lease = null;
+                    WorkspaceList.Lease _lease = ExtensionList.lookupSingleton(ExecutorStepDynamicContext.WorkspaceListLeaseTranslator.class).get(execution.state);
+                    if (_lease != null) {
+                        _lease.release();
                     }
                 } finally {
-                    finish(cookie);
+                    finish(execution.getContext(), cookie);
                 }
-                if (execution != null) {
-                    execution.body = null;
-                    boolean _stopping = execution.state.task.stopping;
-                    execution.state.task.stopping = true;
+                execution.body = null;
+                RunningTasks.run(context, t -> {
+                    boolean _stopping = t.stopping;
+                    t.stopping = true;
                     try {
                         Queue.getInstance().cancel(execution.state.task);
                     } finally {
-                        execution.state.task.stopping = _stopping;
+                        t.stopping = _stopping;
                     }
-                    execution.state = null;
-                    context.saveState();
-                }
+                });
+                execution.state = null;
+                context.saveState();
             }
 
         }
@@ -1020,9 +994,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         env.put("EXECUTOR_NUMBER", String.valueOf(exec.getNumber()));
                         env.put("NODE_LABELS", node.getAssignedLabels().stream().map(Object::toString).collect(Collectors.joining(" ")));
 
-                        RunningTasks.get().withRunningTasks(runningTasks -> {
-                            runningTasks.put(cookie, new RunningTask());
-                        });
                         // For convenience, automatically allocate a workspace, like WorkspaceStep would:
                         Job<?,?> j = r.getParent();
                         if (!(j instanceof TopLevelItem)) {
@@ -1050,12 +1021,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                                 .withContexts(env, state)
                                 .withCallback(new Callback(cookie, execution))
                                 .start();
-                            LOGGER.fine(() -> "started " + cookie + " in " + runId);
+                            LOGGER.fine(() -> "started " + context);
                             context.saveState();
                         });
                     } else {
                         // just rescheduled after a restart; wait for task to complete
-                        LOGGER.fine(() -> "resuming " + cookie + " in " + runId);
+                        LOGGER.fine(() -> "resuming " + context);
                     }
                 } catch (Exception x) {
                     if (computer != null) {
@@ -1074,13 +1045,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 }
                 // wait until the invokeBodyLater call above completes and notifies our Callback object
                 final TaskListener _listener = listener;
-                RunningTasks.get().withRunningTasks(runningTasks -> {
-                    LOGGER.fine(() -> "waiting on " + cookie + " in " + runId);
-                    RunningTask runningTask = runningTasks.get(cookie);
-                    if (runningTask == null) {
-                        LOGGER.fine(() -> "running task apparently finished quickly for " + cookie + " in " + runId);
-                        return;
-                    }
+                RunningTasks.run(context, runningTask -> {
+                    LOGGER.fine(() -> "waiting on " + context);
                     assert runningTask.execution == null;
                     assert runningTask.launcher == null;
                     runningTask.launcher = launcher;
@@ -1089,7 +1055,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                             if (forShutdown) {
                                 return;
                             }
-                            LOGGER.fine(() -> "interrupted " + cookie + " in " + runId);
+                            LOGGER.fine(() -> "interrupted " + context);
                             Timer.get().submit(() -> { // JENKINS-46738
                                 Executor thisExecutor = /* AsynchronousExecution. */ getExecutor();
                                 AtomicReference<Boolean> cancelledBodyExecution = new AtomicReference(false);
@@ -1156,9 +1122,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             }
 
             @Override public boolean willContinue() {
-                return RunningTasks.get().withRunningTasks(runningTasks -> {
-                    return runningTasks.containsKey(cookie);
-                });
+                return hasStarted();
             }
 
             @Restricted(DoNotUse.class) // for Jelly
@@ -1188,8 +1152,6 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             @Override public String toString() {
                 return "PlaceholderExecutable:" + PlaceholderTask.this;
             }
-
-            private static final long serialVersionUID = 1L;
 
             @NonNull
             @Override
@@ -1230,20 +1192,31 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
     @Extension
     public static class RunningTasks {
-        /** keys are {@link PlaceholderTask#cookie}s */
-        private final Map<String, RunningTask> runningTasks = new HashMap<>();
+        private final Map<StepContext, RunningTask> runningTasks = new HashMap<>();
 
-        synchronized <T> T withRunningTasks(Function<Map<String, RunningTask>, T> fn) {
-            return fn.apply(runningTasks);
+        private static RunningTask find(StepContext context) {
+            RunningTasks holder = ExtensionList.lookupSingleton(RunningTasks.class);
+            synchronized (holder) {
+                return holder.runningTasks.computeIfAbsent(context, k -> new RunningTask());
+            }
         }
 
-        synchronized void withRunningTasks(Consumer<Map<String, RunningTask>> fn) {
-            fn.accept(runningTasks);
+        static <T> T get(StepContext context, Function<RunningTask, T> fn) {
+            return fn.apply(find(context));
         }
 
-        static RunningTasks get() {
-            return ExtensionList.lookupSingleton(RunningTasks.class);
+        static void run(StepContext context, Consumer<RunningTask> fn) {
+            fn.accept(find(context));
         }
+
+        static RunningTask remove(StepContext context) {
+            RunningTasks holder = ExtensionList.lookupSingleton(RunningTasks.class);
+            synchronized (holder) {
+                RunningTask t = holder.runningTasks.remove(context);
+                return t != null ? t : new RunningTask();
+            }
+        }
+
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -1213,7 +1213,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
             RunningTasks holder = ExtensionList.lookupSingleton(RunningTasks.class);
             synchronized (holder) {
                 RunningTask t = holder.runningTasks.remove(context);
-                return t != null ? t : new RunningTask();
+                if (t != null) {
+                    return t;
+                } else {
+                    LOGGER.fine(() -> "was no running task information to remove from " + context);
+                    return new RunningTask();
+                }
             }
         }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import hudson.ExtensionList;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.Slave;
+import hudson.model.TaskListener;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.SimpleCommandLauncher;
+import org.jvnet.hudson.test.TestExtension;
+
+/**
+ * Like {@link ExecutorStepTest} but not using {@link Parameterized} which appears incompatible with {@link TestExtension}.
+ */
+public final class ExecutorStep2Test {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsSessionRule rr = new JenkinsSessionRule();
+
+    @Issue("JENKINS-53837")
+    @Test public void queueTaskOwnerCorrectWhenRestarting() throws Throwable {
+        rr.then(r -> {
+            ExtensionList.lookupSingleton(PipelineOnlyTaskDispatcher.class);
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p1");
+            p.setDefinition(new CpsFlowDefinition("node {\n" +
+                    "  semaphore('wait')\n" +
+                    "}", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+        });
+        rr.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p1", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            SemaphoreStep.success("wait/1", null);
+            r.waitForCompletion(b);
+            r.assertBuildStatusSuccess(b);
+            r.assertLogNotContains("Non-Pipeline tasks are forbidden!", b);
+        });
+    }
+    @TestExtension("queueTaskOwnerCorrectWhenRestarting")
+    public static class PipelineOnlyTaskDispatcher extends QueueTaskDispatcher {
+        @Override
+        public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            Queue.Task t = item.task;
+            while (!(t instanceof Item) && (t != null)) {
+                final Queue.Task ownerTask = t.getOwnerTask();
+                if (t == ownerTask) {
+                    break;
+                }
+                t = ownerTask;
+            }
+            if (t instanceof WorkflowJob) {
+                return null;
+            }
+            final Queue.Task finalT = t;
+            return new CauseOfBlockage() {
+                @Override
+                public String getShortDescription() {
+                    return "Non-Pipeline tasks are forbidden! Not building: " + finalT;
+                }
+            };
+        }
+    }
+
+    @Test public void cloud() throws Throwable {
+        rr.then(r -> {
+            ExtensionList.lookupSingleton(TestCloud.DescriptorImpl.class);
+            r.jenkins.clouds.add(new TestCloud());
+            var p = r.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node('test') {}", true));
+            r.assertLogContains("Running on test-1", r.buildAndAssertSuccess(p));
+            r.assertLogContains("Running on test-2", r.buildAndAssertSuccess(p));
+        });
+    }
+    // adapted from org.jenkinci.plugins.mock_slave.MockCloud
+    public static final class TestCloud extends Cloud {
+        TestCloud() {
+            super("test");
+        }
+        @Override public boolean canProvision(Cloud.CloudState state) {
+            var label = state.getLabel();
+            return label != null && label.matches(Label.parse("test"));
+        }
+        @Override public Collection<NodeProvisioner.PlannedNode> provision(Cloud.CloudState state, int excessWorkload) {
+            var r = new ArrayList<NodeProvisioner.PlannedNode>();
+            while (excessWorkload > 0) {
+                r.add(new NodeProvisioner.PlannedNode("test", Computer.threadPoolForRemoting.submit(() -> new TestCloudSlave()), 1));
+                excessWorkload -= 1;
+            }
+            return r;
+        }
+        @TestExtension("cloud") public static final class DescriptorImpl extends Descriptor<Cloud> {
+            private long counter;
+            public DescriptorImpl() {
+                load();
+                NodeProvisioner.NodeProvisionerInvoker.INITIALDELAY = 1000;
+                NodeProvisioner.NodeProvisionerInvoker.RECURRENCEPERIOD = 1000;
+            }
+            synchronized long newNodeNumber() {
+                counter++;
+                save();
+                return counter;
+            }
+        }
+        private static final class TestCloudSlave extends AbstractCloudSlave {
+            TestCloudSlave() throws Exception {
+                this("test-" + ExtensionList.lookupSingleton(TestCloud.DescriptorImpl.class).newNodeNumber());
+            }
+            private TestCloudSlave(String name) throws Exception {
+                super(name, new File(new File(Jenkins.get().getRootDir(), "agents"), name).getAbsolutePath(),
+                        new SimpleCommandLauncher(String.format("\"%s/bin/java\" -jar \"%s\"",
+                            System.getProperty("java.home"),
+                            new File(Jenkins.get().getJnlpJars("agent.jar").getURL().toURI()))));
+                setMode(Node.Mode.EXCLUSIVE);
+                setNumExecutors(1);
+                setLabelString("test");
+                setRetentionStrategy(new OnceRetentionStrategy(1));
+            }
+            @Override public AbstractCloudComputer<?> createComputer() {
+                return new AbstractCloudComputer<>(this);
+            }
+            @Override protected void _terminate(TaskListener listener) {}
+            @TestExtension("cloud") public static final class DescriptorImpl extends Slave.SlaveDescriptor {
+                @Override public boolean isInstantiable() {
+                    return false;
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -1215,7 +1215,7 @@ public class ExecutorStepTest {
             while (Queue.getInstance().getItems().length > 0) {
                 Thread.sleep(100L);
             }
-            assertThat(logging.getMessages(), hasItem(startsWith("Refusing to build ExecutorStepExecution.PlaceholderTask{runId=p#")));
+            assertThat(logging.getMessages(), hasItem(startsWith("Refusing to build ExecutorStepExecution.PlaceholderTask")));
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -40,18 +40,14 @@ import hudson.FilePath;
 import hudson.Functions;
 import hudson.model.Computer;
 import hudson.model.Executor;
-import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Label;
-import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.Slave;
 import hudson.model.User;
 import hudson.model.labels.LabelAtom;
-import hudson.model.queue.CauseOfBlockage;
-import hudson.model.queue.QueueTaskDispatcher;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.slaves.DumbSlave;
@@ -123,7 +119,6 @@ import org.jvnet.hudson.test.JenkinsSessionRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
-import org.jvnet.hudson.test.TestExtension;
 
 /** Tests pertaining to {@code node} and {@code sh} steps. */
 @RunWith(Parameterized.class)
@@ -1077,29 +1072,6 @@ public class ExecutorStepTest {
         });
     }
 
-    /**
-     * @see PipelineOnlyTaskDispatcher
-     */
-    @Issue("JENKINS-53837")
-    @Test public void queueTaskOwnerCorrectWhenRestarting() throws Throwable {
-        sessions.then(r -> {
-            WorkflowJob p = r.createProject(WorkflowJob.class, "p1");
-            p.setDefinition(new CpsFlowDefinition("node {\n" +
-                    "  semaphore('wait')\n" +
-                    "}", true));
-            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-            SemaphoreStep.waitForStart("wait/1", b);
-        });
-        sessions.then(r -> {
-            WorkflowJob p = r.jenkins.getItemByFullName("p1", WorkflowJob.class);
-            WorkflowRun b = p.getBuildByNumber(1);
-            SemaphoreStep.success("wait/1", null);
-            r.waitForCompletion(b);
-            r.assertBuildStatusSuccess(b);
-            r.assertLogNotContains("Non-Pipeline tasks are forbidden!", b);
-        });
-    }
-
     @Issue("JENKINS-58900")
     @Test public void nodeDisconnectMissingContextVariableException() throws Throwable {
         sessions.then(r -> {
@@ -1264,31 +1236,6 @@ public class ExecutorStepTest {
     private static class FallbackAuthenticator extends QueueItemAuthenticator {
         @Override public Authentication authenticate(Queue.Task task) {
             return ACL.SYSTEM;
-        }
-    }
-
-    @TestExtension("queueTaskOwnerCorrectWhenRestarting")
-    public static class PipelineOnlyTaskDispatcher extends QueueTaskDispatcher {
-        @Override
-        public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
-            Queue.Task t = item.task;
-            while (!(t instanceof Item) && (t != null)) {
-                final Queue.Task ownerTask = t.getOwnerTask();
-                if (t == ownerTask) {
-                    break;
-                }
-                t = ownerTask;
-            }
-            if (t instanceof WorkflowJob) {
-                return null;
-            }
-            final Queue.Task finalT = t;
-            return new CauseOfBlockage() {
-                @Override
-                public String getShortDescription() {
-                    return "Non-Pipeline tasks are forbidden! Not building: " + finalT;
-                }
-            };
         }
     }
 


### PR DESCRIPTION
Working on the same test as in #353, I found a (locally unreproducible) case where it appears that `Queue.cancel` from `PlaceholderTask.Callback.finished` triggered `CancelledItemListener`. `PlaceholderTask.stopping` was designed to prevent exactly this; the fact that it did not suggests that there are multiple `PlaceholderTask`s involved. As in #344, the root design flaw is that there is mutable state in `PlaceholderTask` yet it is difficult to ensure Java object identity here. So here I am moving the `stopping` field to transient global state (`RunningTasks`). I am also restoring `cookie` to its original purpose of an actual environment variable value used for nothing more than killing off stray background processes at the end of the block; and using `StepContext` as the primary key whenever we need to look up state. I did consider making `PlaceholderTask` actually immutable but this would require changing the storage of the `label` and `cookie` fields, which is more difficult for two reasons: we need to actually read these values from builds running before the upgrade; and we would need to find some other spot to persist them (such as fields in `ExecutorStepExecution` perhaps). I think these fields are not real problems anyway, since they are only mutated once, in `PlaceholderExecutable.run`, and before that point there does not seem to be a risk of there being multiple copies of the `PlaceholderTask`: the known problems involve deserialization from both the queue and from `ExecutorStepDynamicContext.task`, but `ExecutorStepDynamicContext` is not created until after `cookie` and `label` have been written.