### PR TITLE
`PlaceholderTask.Callback.finished` did not correctly suppress `CancelledItemListener`, and `willContinue` was unreliable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,9 @@
-/*
- See the documentation for more options:
-
-https://github.com/jenkins-infra/pipeline-library/
-
-*/
+configurations = [[platform: 'linux', jdk: 21]]
+if (env.CHANGE_ID == null) { // TODO https://github.com/jenkins-infra/helpdesk/issues/3931 workaround
+  configurations += [platform: 'windows', jdk: 17]
+}
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   forkCount: '1C', 
-  configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
-])
+  configurations: configurations
+)

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -900,6 +900,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 return;
             }
             assert runningTask.launcher != null;
+            runningTask.execution = null;
             Timer.get().submit(() -> execution.completed(null)); // JENKINS-31614
             if (cookie == null) {
                 LOGGER.fine(() -> "no cookie to kill from " + context);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
@@ -122,7 +122,7 @@ public final class ExecutorStep2Test {
             r.jenkins.clouds.add(new TestCloud());
             var p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("node('test') {}", true));
-            logging.record(OnceRetentionStrategy.class, Level.FINE);
+            logging.record(OnceRetentionStrategy.class, Level.FINE).record(ExecutorStepExecution.class, Level.FINE);
             r.assertLogContains("Running on test-1", r.buildAndAssertSuccess(p));
             await("waiting for test-1 to be removed").until(r.jenkins::getNodes, empty());
             r.assertLogContains("Running on test-2", r.buildAndAssertSuccess(p));

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStep2Test.java
@@ -42,7 +42,10 @@ import hudson.slaves.NodeProvisioner;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.logging.Level;
 import jenkins.model.Jenkins;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.empty;
 import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -55,6 +58,7 @@ import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.SimpleCommandLauncher;
 import org.jvnet.hudson.test.TestExtension;
 
@@ -65,6 +69,7 @@ public final class ExecutorStep2Test {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsSessionRule rr = new JenkinsSessionRule();
+    @Rule public LoggerRule logging = new LoggerRule();
 
     @Issue("JENKINS-53837")
     @Test public void queueTaskOwnerCorrectWhenRestarting() throws Throwable {
@@ -117,8 +122,11 @@ public final class ExecutorStep2Test {
             r.jenkins.clouds.add(new TestCloud());
             var p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition("node('test') {}", true));
+            logging.record(OnceRetentionStrategy.class, Level.FINE);
             r.assertLogContains("Running on test-1", r.buildAndAssertSuccess(p));
+            await("waiting for test-1 to be removed").until(r.jenkins::getNodes, empty());
             r.assertLogContains("Running on test-2", r.buildAndAssertSuccess(p));
+            await("waiting for test-2 to be removed").until(r.jenkins::getNodes, empty());
         });
     }
     // adapted from org.jenkinci.plugins.mock_slave.MockCloud


### PR DESCRIPTION
The test motivating #354 flaked again. From the logs, the cause is clear enough: the `RunningTask` was removed before `Queue.cancel` was called, so `CancelledItemListener` was still active. (I have no idea how to reproduce this scenario, leading to the build being aborted.)