### PR TITLE
Fail fast on cloud node removal

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -367,7 +367,7 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                         } else {
                             LOGGER.fine(() -> "rediscovering that " + node + " has been removed and timeout has expired");
                             listener().getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + ", assuming it is not coming back");
-                            throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeCause());
+                            throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeCause(), new ExecutorStepExecution.RemovedNodeTimeoutCause());
                         }
                     }
                     removedNodeDiscovered = 0; // something else; reset

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/ExecutorPickle.java
@@ -122,7 +122,7 @@ public class ExecutorPickle extends Pickle {
                                 Queue.getInstance().cancel(item);
                                 owner.getListener().getLogger().printf("Killed %s after waiting for %s because we assume unknown agent %s is never going to appear%n",
                                         item.task.getDisplayName(), Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS), placeholder.getAssignedLabel());
-                                throw new FlowInterruptedException(Result.ABORTED, new ExecutorStepExecution.RemovedNodeCause());
+                                throw new FlowInterruptedException(Result.ABORTED, new ExecutorStepExecution.RemovedNodeCause(), new ExecutorStepExecution.RemovedNodeTimeoutCause());
                             }
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -107,7 +107,7 @@ public final class ExecutorStepDynamicContext implements Serializable {
             exec = item.getFuture().getStartCondition().get(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException x) {
             listener.getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + ", assuming it is not coming back");
-            throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeCause());
+            throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeCause(), new ExecutorStepExecution.RemovedNodeTimeoutCause());
         } catch (CancellationException x) {
             LOGGER.log(Level.FINE, "ceased to wait for " + node, x);
             throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.QueueTaskCancelled());

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -119,7 +119,6 @@ public class ExecutorStepDynamicContextTest {
         sessions.then(j -> {
             // Start up a build and then reboot and take the node offline
             assertEquals(0, j.jenkins.getLabel("ghost").getNodes().size()); // Make sure test impl is correctly deleted
-            assertNull(j.jenkins.getNode("ghost")); // Make sure test impl is correctly deleted
             WorkflowRun run = j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();
             j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
             j.assertLogContains("slave0 has been removed for ", run);
@@ -234,7 +233,6 @@ public class ExecutorStepDynamicContextTest {
         sessions.then(j -> {
             // Start up a build and then reboot and take the node offline
             assertEquals(0, j.jenkins.getLabel("ghost").getNodes().size()); // Make sure test impl is correctly deleted
-            assertNull(j.jenkins.getNode("ghost")); // Make sure test impl is correctly deleted
             WorkflowRun run = j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();
             j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
             j.assertLogNotContains("slave0 has been removed for ", run);

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -226,14 +226,9 @@ public class ExecutorStepDynamicContextTest {
 
             DumbSlave s = j.createSlave(Label.get("ghost"));
             s.setRetentionStrategy(new OnceRetentionStrategy(0));
-            j.waitForMessage("+ sleep infinity", p.scheduleBuild2(0).waitForStart());
+            var run = p.scheduleBuild2(0).waitForStart();
+            j.waitForMessage("+ sleep infinity", run);
             j.jenkins.removeNode(s);
-        });
-
-        sessions.then(j -> {
-            // Start up a build and then reboot and take the node offline
-            assertEquals(0, j.jenkins.getLabel("ghost").getNodes().size()); // Make sure test impl is correctly deleted
-            WorkflowRun run = j.jenkins.getItemByFullName("p", WorkflowJob.class).getLastBuild();
             j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
             j.assertLogNotContains("slave0 has been removed for ", run);
             assertThat(j.jenkins.getQueue().getItems(), emptyArray());


### PR DESCRIPTION
This cancels the node block immediately instead of waiting for the node to come in certain conditions when we are sure the node can't come back: using a cloud node, using `OnceRetentionStrategy`.

Creating as draft as I'm experiencing test failures when running the full test class
such as

```
[ERROR] org.jenkinsci.plugins.workflow.support.steps.ExecutorStepDynamicContextTest.onceRetentionStrategyNodeDisappearance -- Time elapsed: 3.218 s <<< FAILURE!
java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertNotNull(Assert.java:713)
        at org.junit.Assert.assertNotNull(Assert.java:723)
        at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepDynamicContextTest.lambda$onceRetentionStrategyNodeDisappearance$10(ExecutorStepDynamicContextTest.java:241)
        at org.jvnet.hudson.test.JenkinsSessionRule$2.evaluate(JenkinsSessionRule.java:102)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:656)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

https://github.com/Vlatombe/workflow-durable-task-step-plugin/blob/a68e629a9d4aa35184077d549c52b819ce4add23/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java#L240


But I don't exactly get where this comes from

- **Fail fast after cloud node removal**
- **Remove useless assertion**

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
