### PR TITLE
Extending `AnomalousStatus` to also kill `sh` steps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java
@@ -257,7 +257,8 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
      * {@link #ws} is nulled out and Jenkins waits until a fresh handle is available.
      */
     @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="recurrencePeriod is set in onResume, not deserialization")
-    static final class Execution extends AbstractStepExecutionImpl implements Runnable, ExecutionRemotable {
+    @Restricted(NoExternalUse.class)
+    public static final class Execution extends AbstractStepExecutionImpl implements Runnable, ExecutionRemotable {
 
         private static final long MIN_RECURRENCE_PERIOD = 250; // ¼s
         private static final long MAX_RECURRENCE_PERIOD = 15000; // 15s
@@ -282,7 +283,7 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
         /** Serialized state of the controller. */
         private Controller controller;
         /** {@link Node#getNodeName} of {@link #ws}. */
-        private String node;
+        public String node;
         /** {@link FilePath#getRemote} of {@link #ws}. */
         private String remote;
         /** Whether the entire stdout of the process is to become the return value of the step. */
@@ -366,7 +367,7 @@ public abstract class DurableTaskStep extends Step implements EnvVarsFilterableB
                             return null;
                         } else {
                             LOGGER.fine(() -> "rediscovering that " + node + " has been removed and timeout has expired");
-                            listener().getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + ", assuming it is not coming back");
+                            listener().getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + "; assuming it is not coming back, and terminating shell step");
                             throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeTimeoutCause());
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -110,7 +110,7 @@ public final class ExecutorStepDynamicContext implements Serializable {
             exec = item.getFuture().getStartCondition().get(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException x) {
             LOGGER.log(Level.FINE, x, () -> "failed to wait for " + item + "; outstanding queue items: " + Arrays.toString(Queue.getInstance().getItems()) + "; running executables: " + Stream.of(Jenkins.get().getComputers()).flatMap(c -> c.getExecutors().stream()).collect(Collectors.toList()));
-            listener.getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + ", assuming it is not coming back");
+            listener.getLogger().println(node + " has been removed for " + Util.getTimeSpanString(ExecutorStepExecution.TIMEOUT_WAITING_FOR_NODE_MILLIS) + "; assuming it is not coming back, and terminating node step");
             throw new FlowInterruptedException(Result.ABORTED, /* TODO false probably more appropriate */true, new ExecutorStepExecution.RemovedNodeTimeoutCause());
         } catch (CancellationException x) {
             LOGGER.log(Level.FINE, "ceased to wait for " + node, x);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -277,12 +277,12 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
     @Extension public static final class AnomalousStatus extends PeriodicWork {
 
         @Override public long getRecurrencePeriod() {
-            return Duration.ofMinutes(30).toMillis();
+            return Duration.ofMinutes(5).toMillis();
         }
 
         @Override public long getInitialDelay() {
             // Do not run too soon after startup, in case things are still loading, agents are still reattaching, etc.
-            return Duration.ofMinutes(15).toMillis();
+            return Duration.ofMinutes(7).toMillis();
         }
 
         /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -159,7 +159,7 @@ public class ExecutorStepDynamicContextTest {
             j.assertLogNotContains("assuming it is not coming back", b);
             j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
             for (int i = 0; i < 5; i++) {
-                j.assertLogContains("slave" + i + " has been removed for 15 sec, assuming it is not coming back", b);
+                j.assertLogContains("slave" + i + " has been removed for 15 sec; assuming it is not coming back, and terminating node step", b);
             }
             assertThat(logging.getRecords().stream().filter(r -> r.getLevel().intValue() >= Level.WARNING.intValue()).toArray(), emptyArray());
         });

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepTest.java
@@ -531,7 +531,7 @@ public class ExecutorStepTest {
                 SemaphoreStep.success("wait/1", null);
                 r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
                 assertEquals(Collections.emptyList(), Arrays.asList(Queue.getInstance().getItems()));
-                r.assertLogContains("dumbo has been removed for 15 sec, assuming it is not coming back", b);
+                r.assertLogContains("dumbo has been removed for 15 sec; assuming it is not coming back, and terminating node step", b);
         });
     }
 


### PR DESCRIPTION
In many cases when restoring a build into another K8s cluster using a very lossy backup of the filesystem, via EFS Replication (which does not guarantee snapshot semantics), there is some sort of problem with metadata, which prevents `node` block retry from recovering automatically. (Prior to https://github.com/jenkinsci/kubernetes-plugin/pull/1617 it did not work even if metadata was perfect.) Sometimes there is a missing `program.dat`, sometimes a corrupted log file, sometimes a missing `FlowNode`, etc.

But in many of these cases ([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-53259)), the log seems fine and the flow nodes seem fine, yet for reasons I cannot easily follow because `program.dat` is so opaque, the `node` block seems to have received an `Outcome.abnormal` with the expected `FlowInterrupedException` from `ExecutorStepDynamicContext.resume`; there are also some suppressed exceptions, and `AnomalousStatus` just adds to this list, without causing the build to proceed. Calling `CpsStepContext.scheduleNextRun()` from the script console does not help either. However in most of these cases it _does_ seem to work to abort the `sh` step running inside: somehow that “wakes up” the program, which then fails the `node` block in the expected way, letting the `retry` step kick in and ultimately letting the build run to completion.