### PR TITLE
Fix running tests on MacOS

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStepTest.java
@@ -26,6 +26,8 @@ package org.jenkinsci.plugins.workflow.steps.durable_task;
 
 import hudson.ExtensionList;
 import hudson.Functions;
+import hudson.Platform;
+import hudson.Util;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
@@ -121,7 +123,8 @@ public final class DurableTaskStepTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         // In the case of Bourne shell, `+ touch …` is printed when the command actually runs.
         // In the case of batch shell, the whole command is printed immediately, so we need to assert that the _output_ of `dir` is there.
-        r.assertLogContains(Functions.isWindows() ? "Directory of " + r.jenkins.getRootDir() : "+ touch " + new File(r.jenkins.getRootDir(), "f"), b);
+        var file = new File(r.jenkins.getRootDir(), "f");
+        r.assertLogContains(Functions.isWindows() ? "Directory of " + r.jenkins.getRootDir() : "+ touch " + (Platform.isDarwin() ? Util.singleQuote(file.toString()) : file), b);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -22,6 +22,7 @@ import hudson.Functions;
 import hudson.Launcher;
 import hudson.LauncherDecorator;
 import hudson.MarkupText;
+import hudson.Platform;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleLogFilter;
@@ -248,6 +249,8 @@ public class ShellStepTest {
 
     @Test public void launcherDecorator() throws Exception {
         Assume.assumeTrue("TODO Windows equivalent TBD", new File("/usr/bin/nice").canExecute());
+        // https://stackoverflow.com/questions/44811425/nice-command-not-working-on-macos
+        Assume.assumeFalse("MacOS doesn't implement nice", Platform.isDarwin());
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node {sh 'echo niceness=`nice`'}", true));
         Assume.assumeThat("test only works if mvn test is not itself niced", JenkinsRule.getLog(j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsString("niceness=0"));


### PR DESCRIPTION
I'm hitting a few failures running the existing tests on MacOS due to behavioural differences with linux.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
