### PR TITLE
Build fails to resume if controller crashes before queue is saved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,8 @@
         <changelist>999999-SNAPSHOT</changelist>
         <!-- TODO Until in plugin-pom -->
         <jenkins-test-harness.version>2357.vf2a_982b_b_910f</jenkins-test-harness.version>
-        <jenkins.version>2.479.1</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
@@ -77,7 +78,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.479.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>3613.v584fca_12cf5c</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- TODO Until in plugin-pom -->
-        <jenkins-test-harness.version>2182.v0138ccb_c0b_cb_</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2357.vf2a_982b_b_910f</jenkins-test-harness.version>
         <jenkins.version>2.440.1</jenkins.version>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -114,6 +114,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-input-step</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.479.x</artifactId>
-                <version>3696.vb_b_4e2d1a_0542</version>
+                <version>3613.v584fca_12cf5c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3613.v584fca_12cf5c</version>
+                <version>3482.vc10d4f6da_28a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.3</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <!-- TODO Until in plugin-pom -->
         <jenkins-test-harness.version>2357.vf2a_982b_b_910f</jenkins-test-harness.version>
-        <jenkins.version>2.440.1</jenkins.version>
+        <jenkins.version>2.479.1</jenkins.version>
         <useBeta>true</useBeta>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <hpi.compatibleSinceVersion>2.40</hpi.compatibleSinceVersion>
@@ -77,8 +77,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.440.x</artifactId>
-                <version>2907.vcb_35d6f2f7de</version>
+                <artifactId>bom-2.479.x</artifactId>
+                <version>3696.vb_b_4e2d1a_0542</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -216,7 +216,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
         try {
             if (state == null) {
                 var flowNode = getContext().get(FlowNode.class);
-                LOGGER.fine(() -> "No ExecutorStepDynamicContext found for node block " + getContext() + "; will attempt to recover");
+                LOGGER.fine(() -> "node block " + getContext() + " not yet scheduled, checking for an existing queue item");
                 if (flowNode == null) {
                     LOGGER.fine(() -> "No FlowNode found for node block " + getContext() + "; can't recover" );
                 } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -225,7 +225,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         LOGGER.fine(() -> "No QueueItemAction found for node block " + getContext() + "; can't recover");
                     } else {
                         LOGGER.fine(() -> "QueueItemAction with id=" + action.id + " found for node block " + getContext());
-                        var queueItem = Queue.getInstance().getItem(action.id);
+                        var queueItem = action.itemInQueue();
                         if (queueItem == null) {
                             LOGGER.fine(() -> "Could not find queue item " + action.id + ", rescheduling it");
                             start();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -215,8 +215,25 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
     @Override public void onResume() {
         try {
             if (state == null) {
-                Run<?, ?> run = getContext().get(Run.class);
-                LOGGER.fine(() -> "No ExecutorStepDynamicContext found for node block in " + run + "; perhaps loading from a historical build record, hoping for the best");
+                var flowNode = getContext().get(FlowNode.class);
+                LOGGER.fine(() -> "No ExecutorStepDynamicContext found for node block " + getContext() + "; will attempt to recover");
+                if (flowNode == null) {
+                    LOGGER.fine(() -> "No FlowNode found for node block " + getContext() + "; can't recover" );
+                } else {
+                    var action = flowNode.getAction(QueueItemActionImpl.class);
+                    if (action == null) {
+                        LOGGER.fine(() -> "No QueueItemAction found for node block " + getContext() + "; can't recover");
+                    } else {
+                        LOGGER.fine(() -> "QueueItemAction with id=" + action.id + " found for node block " + getContext());
+                        var queueItem = Queue.getInstance().getItem(action.id);
+                        if (queueItem == null) {
+                            LOGGER.fine(() -> "Could not find queue item " + action.id + ", rescheduling it");
+                            start();
+                        } else {
+                            LOGGER.fine(() -> "Found Queue.Item " + queueItem + " for node block " + getContext() + "; should be fine");
+                        }
+                    }
+                }
                 return;
             }
             state.resume(getContext());

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -228,6 +228,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         var queueItem = action.itemInQueue();
                         if (queueItem == null) {
                             LOGGER.fine(() -> "Could not find queue item " + action.id + ", rescheduling it");
+                            flowNode.removeActions(QueueItemActionImpl.class);
                             start();
                         } else {
                             LOGGER.fine(() -> "Found Queue.Item " + queueItem + " for node block " + getContext() + "; should be fine");

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextRJRTest.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2024, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.InboundAgentRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.PrefixedOutputStream;
+import org.jvnet.hudson.test.RealJenkinsRule;
+import org.jvnet.hudson.test.TailLog;
+
+public class ExecutorStepDynamicContextRJRTest {
+    private static final Logger LOGGER = Logger.getLogger(ExecutorStepDynamicContextRJRTest.class.getName());
+
+    @Rule public RealJenkinsRule rjr = new RealJenkinsRule().withColor(PrefixedOutputStream.Color.GREEN).withPackageLogger(ExecutorStepExecution.class, Level.FINE).withPackageLogger(FlowExecutionList.class, Level.FINE);
+
+    @Rule
+    public InboundAgentRule iar = new InboundAgentRule();
+
+    @Test public void restartWhileWaitingForANode() throws Throwable {
+        rjr.startJenkins();
+        try (var tailLog = new TailLog(rjr, "p", 1)) {
+            iar.createAgent(rjr, InboundAgentRule.Options.newBuilder().name("J").label("mib").color(PrefixedOutputStream.Color.YELLOW).webSocket().build());
+            rjr.runRemotely(ExecutorStepDynamicContextRJRTest::setupJobAndStart);
+            rjr.stopJenkinsForcibly();
+            rjr.startJenkins();
+            rjr.runRemotely(ExecutorStepDynamicContextRJRTest::assertQueueItems);
+        }
+    }
+
+    private static void assertQueueItems(JenkinsRule r) throws Throwable {
+        var p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+        var b = p.getBuildByNumber(1);
+        var items = await("Waiting for agent J to reconnect").atMost(Duration.ofSeconds(30)).until(() -> r.jenkins.getQueue().getItems(), arrayWithSize(1));
+        LOGGER.info("Items in queue: " + Arrays.asList(items));
+        var actions = await().until(() -> b.getActions(InputAction.class), hasSize(1));
+        proceed(actions, "Complete branch 1 ?", p.getName() + "#" + b.number);
+        actions = await().until(() -> b.getActions(InputAction.class), allOf(iterableWithSize(1), hasItem(new InputActionIsWaitingForInput())));
+        r.waitForMessage("Complete branch 2 ?", b);
+        proceed(actions, "Complete branch 2 ?", p.getName() + "#" + b.number);
+        r.waitForCompletion(b);
+    }
+
+    private static class InputActionIsWaitingForInput extends TypeSafeMatcher<InputAction> {
+
+        @Override
+        protected boolean matchesSafely(InputAction inputAction) {
+            try {
+                return inputAction.isWaitingForInput();
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("is waiting for input");
+        }
+    }
+
+    private static void proceed(List<InputAction> actions, String inputMessage, String name) throws InterruptedException, TimeoutException, IOException {
+        for (var action : actions) {
+            if (action.getExecutions().isEmpty()) {
+                continue;
+            }
+            var inputStepExecution = action.getExecutions().get(0);
+            if (inputMessage.equals(inputStepExecution.getDisplayName())) {
+                LOGGER.info(() -> "proceeding " + name);
+                inputStepExecution.proceed(null);
+                break;
+            }
+        }
+    }
+
+    private static void setupJobAndStart(JenkinsRule r) throws Exception {
+        var p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("parallel 'Branch 1': { node('mib') { input 'Complete branch 1 ?' } }, 'Branch 2': { sleep 1; node('mib') { input 'Complete branch 2 ?' } }", true));
+        var b = p.scheduleBuild2(0).waitForStart();
+        r.waitForMessage("Complete branch 1 ?", b);
+        assertTrue(b.isBuilding());
+        await().until(() -> r.jenkins.getQueue().getItems(), arrayWithSize(1));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextRJRTest.java
@@ -43,6 +43,8 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.NodeStepTypePredicate;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.junit.Rule;
@@ -129,5 +131,8 @@ public class ExecutorStepDynamicContextRJRTest {
         r.waitForMessage("Complete branch 1 ?", b);
         assertTrue(b.isBuilding());
         await().until(() -> r.jenkins.getQueue().getItems(), arrayWithSize(1));
+        LOGGER.info("Node steps: " + new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("node")));
+        // "Branch 1", "Branch 2" and the second node step ? Not fully clear
+        await().until(() -> new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("node")), hasSize(3));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
@@ -143,7 +143,7 @@ public class ExecutorStepExecutionRJRTest {
         assertTrue(b.isBuilding());
         await().until(() -> r.jenkins.getQueue().getItems(), arrayWithSize(1));
         LOGGER.info("Node steps: " + new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("node")));
-        // "Branch 1", "Branch 2" and the second node step ? Not fully clear
+        // "Branch 1" step start + "Branch 1" body start + "Branch 2" step start
         await().until(() -> new DepthFirstScanner().filteredNodes(b.getExecution(), new NodeStepTypePredicate("node")), hasSize(3));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
@@ -126,7 +126,18 @@ public class ExecutorStepExecutionRJRTest {
 
     private static void setupJobAndStart(JenkinsRule r) throws Exception {
         var p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("parallel 'Branch 1': { node('mib') { input id: 'Branch1', message: 'Complete branch 1 ?' } }, 'Branch 2': { sleep 1; node('mib') { input id:'Branch2', message: 'Complete branch 2 ?' } }", true));
+        p.setDefinition(new CpsFlowDefinition("""
+                parallel 'Branch 1': {
+                    node('mib') {
+                        input id: 'Branch1', message: 'Complete branch 1 ?'
+                    }
+                }, 'Branch 2': {
+                    sleep 1
+                    node('mib') {
+                        input id:'Branch2', message: 'Complete branch 2 ?'
+                    }
+                }
+                """, true));
         var b = p.scheduleBuild2(0).waitForStart();
         r.waitForMessage("Complete branch 1 ?", b);
         assertTrue(b.isBuilding());

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
@@ -55,8 +55,8 @@ import org.jvnet.hudson.test.PrefixedOutputStream;
 import org.jvnet.hudson.test.RealJenkinsRule;
 import org.jvnet.hudson.test.TailLog;
 
-public class ExecutorStepDynamicContextRJRTest {
-    private static final Logger LOGGER = Logger.getLogger(ExecutorStepDynamicContextRJRTest.class.getName());
+public class ExecutorStepExecutionRJRTest {
+    private static final Logger LOGGER = Logger.getLogger(ExecutorStepExecutionRJRTest.class.getName());
 
     @Rule public RealJenkinsRule rjr = new RealJenkinsRule().withColor(PrefixedOutputStream.Color.GREEN).withPackageLogger(ExecutorStepExecution.class, Level.FINE).withPackageLogger(FlowExecutionList.class, Level.FINE);
 
@@ -67,14 +67,14 @@ public class ExecutorStepDynamicContextRJRTest {
         rjr.startJenkins();
         try (var tailLog = new TailLog(rjr, "p", 1)) {
             iar.createAgent(rjr, InboundAgentRule.Options.newBuilder().name("J").label("mib").color(PrefixedOutputStream.Color.YELLOW).webSocket().build());
-            rjr.runRemotely(ExecutorStepDynamicContextRJRTest::setupJobAndStart);
+            rjr.runRemotely(ExecutorStepExecutionRJRTest::setupJobAndStart);
             rjr.stopJenkinsForcibly();
             rjr.startJenkins();
-            rjr.runRemotely(ExecutorStepDynamicContextRJRTest::assertQueueItems);
+            rjr.runRemotely(ExecutorStepExecutionRJRTest::resumeCompleteBranch1ThenBranch2);
         }
     }
 
-    private static void assertQueueItems(JenkinsRule r) throws Throwable {
+    private static void resumeCompleteBranch1ThenBranch2(JenkinsRule r) throws Throwable {
         var p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
         var b = p.getBuildByNumber(1);
         await("Waiting for agent J to reconnect").atMost(Duration.ofSeconds(30)).until(() -> r.jenkins.getComputer("J").isOnline(), is(true));

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecutionRJRTest.java
@@ -77,7 +77,7 @@ public class ExecutorStepExecutionRJRTest {
     private static void resumeCompleteBranch1ThenBranch2(JenkinsRule r) throws Throwable {
         var p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
         var b = p.getBuildByNumber(1);
-        await("Waiting for agent J to reconnect").atMost(Duration.ofSeconds(30)).until(() -> r.jenkins.getComputer("J").isOnline(), is(true));
+        await("Waiting for agent J to reconnect").atMost(Duration.ofSeconds(30)).until(() -> r.jenkins.getComputer("J").isOnline());
         var actions = await().until(() -> b.getActions(InputAction.class), allOf(iterableWithSize(1), hasItem(new InputActionWithId("Branch1"))));
         proceed(actions, "Branch1", p.getName() + "#" + b.number);
         // This is quicker than waitForMessage that can wait for up to 10 minutes


### PR DESCRIPTION
This covers a case where a queue item for a node was filed, then the controller shut down without going through clean up.
Because of that, the queue wasn't saved, and when the controller restarts, the queue item is gone.

This modifies the behaviour of `ExecutorStepExecution#onResume` to detect this condition and re-schedule a new queue item if needed.

### Testing done

See provided unit test.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
