### PR TITLE
Remove `forkCount`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-  forkCount: '1C', 
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],


### PR DESCRIPTION
Too much parallelism appears to be causing test flakiness.