### PR TITLE
Sleep longer in the Windows tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -707,13 +707,11 @@ public class ShellStepTest {
     @Issue("JENKINS-28822")
     @Test public void interruptingAbortsBuild() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        // Test fails unexpectedly on ci.jenkins.io Windows agents when watching
-        // Use a longer timeout when watching and running on Windows
-        int sleepTime = Functions.isWindows() ? 19 : 6;
+        // Test fails unexpectedly on ci.jenkins.io Windows agents with fewer pings
         p.setDefinition(new CpsFlowDefinition("node {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {" +
                 (Functions.isWindows()
-                        ? "bat 'ping -n " + sleepTime + " 127.0.0.1 >nul'\n"
+                        ? "bat 'ping -n 19 127.0.0.1 >nul'\n"
                         : "sh 'sleep 5'\n") +
                 "  }" +
                 "}", true));
@@ -727,10 +725,11 @@ public class ShellStepTest {
     @Issue("JENKINS-28822")
     @Test public void interruptingAbortsBuildEvenWithReturnStatus() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        // Test fails unexpectedly on ci.jenkins.io Windows agents with fewer pings
         p.setDefinition(new CpsFlowDefinition("node() {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {\n" +
                 (Functions.isWindows()
-                        ? "bat(returnStatus: true, script: 'ping -n 6 127.0.0.1 >nul')\n"
+                        ? "bat(returnStatus: true, script: 'ping -n 19 127.0.0.1 >nul')\n"
                         : "sh(returnStatus: true, script: 'sleep 5')\n") +
                 "  }\n" +
                 "}", true));

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -662,12 +662,25 @@ public class ShellStepTest {
     @Test public void deadStep() throws Exception {
         logging.record(DurableTaskStep.class, Level.INFO).record(CpsStepContext.class, Level.INFO).capture(100);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep 1000000') : bat('ping -t 127.0.0.1 > nul')}} catch (e) {sleep 1; throw e}", true));
+        int sleepTime = Functions.isWindows() ? 13 : 1;
+        p.setDefinition(new CpsFlowDefinition("""
+                                              try {
+                                                node {
+                                                  isUnix() ? sh('sleep 1000000') : bat('ping -t 127.0.0.1 > nul')
+                                                }
+                                              } catch (e) {
+                                                sleep %d;
+                                                throw e
+                                              }
+                                              """.formatted(sleepTime), true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
         b.doTerm();
         j.waitForCompletion(b);
         j.assertBuildStatus(Result.ABORTED, b);
+        if (Functions.isWindows()) {
+            Thread.sleep(sleepTime * 1000L);
+        }
         for (LogRecord record : logging.getRecords()) {
             assertNull(record.getThrown());
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -662,16 +662,16 @@ public class ShellStepTest {
     @Test public void deadStep() throws Exception {
         logging.record(DurableTaskStep.class, Level.INFO).record(CpsStepContext.class, Level.INFO).capture(100);
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
-        // Test fails on ci.jenkins.io with timeout == 1 on Windows when watching
-        int sleepTime = Functions.isWindows() && useWatching ? 13 : 1;
+        // Test fails on ci.jenkins.io with timeout == 1 on Windows
+        int sleepTime = Functions.isWindows() ? 13 : 1;
         p.setDefinition(new CpsFlowDefinition("try {node {isUnix() ? sh('sleep 1000000') : bat('ping -t 127.0.0.1 > nul')}} catch (e) {sleep " + sleepTime + "; throw e}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         j.waitForMessage(Functions.isWindows() ? ">ping" : "+ sleep", b);
         b.doTerm();
         j.waitForCompletion(b);
         j.assertBuildStatus(Result.ABORTED, b);
-        // Test fails on ci.jenkins.io with timeout == 1 on Windows when watching
-        if (Functions.isWindows() && useWatching) {
+        // Test fails on ci.jenkins.io with timeout == 1 on Windows
+        if (Functions.isWindows()) {
             Thread.sleep(sleepTime * 1000L);
         }
         for (LogRecord record : logging.getRecords()) {
@@ -709,7 +709,7 @@ public class ShellStepTest {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
         // Test fails unexpectedly on ci.jenkins.io Windows agents when watching
         // Use a longer timeout when watching and running on Windows
-        int sleepTime = Functions.isWindows() && useWatching ? 19 : 6;
+        int sleepTime = Functions.isWindows() ? 19 : 6;
         p.setDefinition(new CpsFlowDefinition("node {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {" +
                 (Functions.isWindows()

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/durable_task/ShellStepTest.java
@@ -707,10 +707,13 @@ public class ShellStepTest {
     @Issue("JENKINS-28822")
     @Test public void interruptingAbortsBuild() throws Exception {
         WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        // Test fails unexpectedly on ci.jenkins.io Windows agents when watching
+        // Use a longer timeout when watching and running on Windows
+        int sleepTime = Functions.isWindows() && useWatching ? 19 : 6;
         p.setDefinition(new CpsFlowDefinition("node {\n" +
                 "  timeout(time: 1, unit: 'SECONDS') {" +
                 (Functions.isWindows()
-                        ? "bat 'ping -n 6 127.0.0.1 >nul'\n"
+                        ? "bat 'ping -n " + sleepTime + " 127.0.0.1 >nul'\n"
                         : "sh 'sleep 5'\n") +
                 "  }" +
                 "}", true));


### PR DESCRIPTION
## Fix failing Windows tests by accepting longer delays

Not changing production code, just adapting tests to the most recent Windows agents attached to ci.jenkins.io

### Testing done

Passes on my Windows computer and on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
