### PR TITLE
NPE in `ExecutorStepExecution$PlaceholderTask$Callback.finished`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -1031,10 +1031,13 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     return;
                 }
                 LOGGER.log(FINE, "finished {0}", execution.getContext());
+                var state = execution.state;
                 try {
-                    WorkspaceList.Lease _lease = ExtensionList.lookupSingleton(ExecutorStepDynamicContext.WorkspaceListLeaseTranslator.class).get(execution.state);
-                    if (_lease != null) {
-                        _lease.release();
+                    if (state != null) {
+                        WorkspaceList.Lease _lease = ExtensionList.lookupSingleton(ExecutorStepDynamicContext.WorkspaceListLeaseTranslator.class).get(state);
+                        if (_lease != null) {
+                            _lease.release();
+                        }
                     }
                 } finally {
                     finish(execution.getContext(), cookie);
@@ -1045,7 +1048,9 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     boolean _stopping = t.stopping;
                     t.stopping = true;
                     try {
-                        if (Queue.getInstance().cancel(execution.state.task)) {
+                        if (state == null) {
+                            LOGGER.fine(() -> execution.getContext() + " not yet scheduled");
+                        } else if (Queue.getInstance().cancel(state.task)) {
                             LOGGER.fine(() -> "cancelled leftover task from " + execution.getContext());
                         } else {
                             LOGGER.fine(() -> "was unable to cancel any leftover task from " + execution.getContext());


### PR DESCRIPTION
Not sure how to reproduce, but observed in a controller log:

```
java.lang.NullPointerException: Cannot read field "lease" because "c" is null
	at PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepDynamicContext$WorkspaceListLeaseTranslator.get(ExecutorStepDynamicContext.java:210)
	at PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask$Callback.finished(ExecutorStepExecution.java:1032)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback$TailCall.onFailure(BodyExecutionCallback.java:129)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsBodyExecution$FailureAdapter.receive(CpsBodyExecution.java:357)
	at PluginClassLoader for workflow-cps//com.cloudbees.groovy.cps.impl.ThrowBlock$1.receive(ThrowBlock.java:66)
	at …
```

The program in this case was of the form

```groovy
pipeline {
  agent {
    label '…'
  }
  stages {
    stage('…') {
      steps {
        script {
          sh '…long sleep…'
        }
      }
    }
  }
}
```

The build was manually aborted in the middle of the `sh` step, resulting in a 143 as expected, but then this fatal error. Build was resumed across a controller restart, but output unexpectedly seemed to indicate that the whole program was starting from scratch. So something was apparently wrong with the build metadata and this null field is presumably just a side effect of that (we would not expect `state` to be null here once we already have a `PlaceholderTask`).
