### PR TITLE
Improved logging in `AnomalousStatus`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -338,7 +338,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         try {
                             ctx.get(TaskListener.class).error("node block still appears to be neither running nor scheduled; cancelling");
                         } catch (IOException | InterruptedException x) {
-                            LOGGER.log(Level.WARNING, null, x);
+                            LOGGER.log(Level.WARNING, "failed to warn about " + ctx, x);
                         }
                         ctx.onFailure(new FlowInterruptedException(Result.ABORTED, false, new QueueTaskCancelled()));
                         try {
@@ -351,7 +351,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                                                 nested.getContext().onFailure(new FlowInterruptedException(Result.ABORTED, false, new RemovedNodeCause()));
                                             }
                                         } catch (IOException | InterruptedException x) {
-                                            LOGGER.log(Level.WARNING, null, x);
+                                            LOGGER.log(Level.WARNING, "failed to check " + nested.getContext() + " in " + ctx, x);
                                         }
                                     }
                                 }
@@ -360,7 +360,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                                 }
                             }, MoreExecutors.directExecutor());
                         } catch (IOException | InterruptedException x) {
-                            LOGGER.log(Level.WARNING, null, x);
+                            LOGGER.log(Level.WARNING, "failed to check " + ctx, x);
                         }
                     } else {
                         newAnomalous.add(ctx);
@@ -370,7 +370,11 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                 }
             }).get();
             for (StepContext ctx : newAnomalous) {
-                ctx.get(TaskListener.class).error("node block appears to be neither running nor scheduled; will cancel if this condition persists");
+                try {
+                    ctx.get(TaskListener.class).error("node block appears to be neither running nor scheduled; will cancel if this condition persists");
+                } catch (IOException | InterruptedException x) {
+                    LOGGER.log(Level.WARNING, "failed to warn about " + ctx, x);
+                }
             }
             LOGGER.fine(() -> "done checking: " + anomalous + " → " + newAnomalous);
             anomalous = newAnomalous;


### PR DESCRIPTION
Unhelpful message found in a system log:

```
SEVERE Timer task org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$AnomalousStatus@abcd1234 failed
java.io.IOException: no node found for 99
        at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsStepContext.getNode(CpsStepContext.java:304)
        at PluginClassLoader for workflow-support//org.jenkinsci.plugins.workflow.support.DefaultStepContext.getListener(DefaultStepContext.java:133)
        at PluginClassLoader for workflow-support//org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:109)
        at PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$AnomalousStatus.doRun(ExecutorStepExecution.java:370)
        at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:92)
        at …
```

Should at least mention which build was being processed.
