### PR TITLE
`ContinuedTask` cannot rely on queue scheduling order

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContext.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.support.steps;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
@@ -143,6 +144,11 @@ public final class ExecutorStepDynamicContext implements Serializable {
         return "ExecutorStepDynamicContext[" + path + "@" + node + "]";
     }
 
+    @CheckForNull Node getNode() {
+        Jenkins j = Jenkins.get();
+        return node.isEmpty() ? j : j.getNode(node);
+    }
+
     private static abstract class Translator<T> extends DynamicContext.Typed<T> {
 
         @Override protected T get(DelegatedContext context) throws IOException, InterruptedException {
@@ -251,8 +257,7 @@ public final class ExecutorStepDynamicContext implements Serializable {
             if (c == null) {
                 return null;
             }
-            Jenkins j = Jenkins.get();
-            return c.node.isEmpty() ? j : j.getNode(c.node);
+            return c.getNode();
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -747,7 +747,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
         @Override public @CheckForNull Queue.Executable getOwnerExecutable() {
             Run<?, ?> r = runForDisplay();
-            return r instanceof Queue.Executable ? (Queue.Executable) r : null;
+            return r instanceof Queue.Executable qe ? qe : null;
         }
 
         @Exported
@@ -1042,6 +1042,10 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         if (_lease != null) {
                             _lease.release();
                         }
+                        var node = state.getNode();
+                        if (node != null) {
+                            UsageTracker.unregister(node, state.task);
+                        }
                     }
                 } finally {
                     finish(execution.getContext(), cookie);
@@ -1104,6 +1108,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                         // Switches the label to a self-label, so if the executable is killed and restarted, it will run on the same node:
                         label = computer.getName();
                         labelIsSelfLabel = true;
+                        UsageTracker.register(node, PlaceholderTask.this);
 
                         EnvVars env = computer.getEnvironment();
                         env.overrideExpandingAll(computer.buildEnvironment(listener));

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java
@@ -154,7 +154,7 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
                     cob.print(listener);
                 }
             }
-        }, 15, TimeUnit.SECONDS);
+        }, Main.isUnitTest ? 5 : 15, TimeUnit.SECONDS);
         return false;
     }
 
@@ -508,8 +508,8 @@ public class ExecutorStepExecution extends AbstractStepExecutionImpl {
 
         private Object readResolve() {
             RunningTasks.add(context);
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(FINE, null, new Exception("deserializing previously scheduled " + this));
+            if (LOGGER.isLoggable(Level.FINER)) {
+                LOGGER.log(FINER, null, new Exception("deserializing previously scheduled " + this));
             }
             return this;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/UsageTracker.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/UsageTracker.java
@@ -1,0 +1,135 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps;
+
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.QueueTaskDispatcher;
+import hudson.slaves.NodeProperty;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import org.jenkinsci.plugins.durabletask.executors.ContinuedTask;
+
+// TODO move to ContinuedTask once tested
+
+/**
+ * Serves essentially the same function as {@link ContinuedTask}, but more reliably:
+ * the block on an agent in use does not rely on a {@link Queue.Item} having been scheduled.
+ */
+final class UsageTracker extends NodeProperty<Node> {
+
+    private static final Logger LOGGER = Logger.getLogger(UsageTracker.class.getName());
+
+    final List<ContinuedTask> tasks;
+
+    private UsageTracker(List<ContinuedTask> tasks) {
+        this.tasks = tasks;
+    }
+
+    // TODO cannot use NodeProperty.canTake because NodeProperty.setNode is never called
+
+    @Extension public static final class QTD extends QueueTaskDispatcher {
+        @Override public CauseOfBlockage canTake(Node node, Queue.BuildableItem item) {
+            if (item.task instanceof ContinuedTask ct && ct.isContinued()) {
+                LOGGER.finer(() -> item.task + " is a continued task, so we are not blocking it");
+                return null;
+            }
+            var prop = node.getNodeProperty(UsageTracker.class);
+            if (prop == null) {
+                LOGGER.finer(() -> "not blocking " + item.task + " since " + node + " has no registrations");
+                return null;
+            }
+            var c = node.toComputer();
+            if (c == null) {
+                LOGGER.finer(() -> "not blocking " + item + " since " + node + " has no computer");
+                return null;
+            }
+            var executors = c.getExecutors();
+            TASK: for (var task : prop.tasks) {
+                for (var executor : executors) {
+                    var executable = executor.getCurrentExecutable();
+                    if (executable != null && executable.getParent().equals(task)) {
+                        LOGGER.finer(() -> "not blocking " + item + " due to " + task + " since that is already running on " + c);
+                        continue TASK;
+                    }
+                }
+                if (task.getOwnerExecutable() instanceof Run<?, ?> build && !build.isInProgress()) {
+                    LOGGER.finer(() -> "not blocking " + item + " due to " + task + " on " + c + " since " + build + " was already completed");
+                    // TODO unregister stale entry
+                    continue;
+                }
+                LOGGER.fine(() -> "blocking " + item.task + " in favor of " + task + " slated to run on " + c);
+                return new HoldOnPlease(task);
+            }
+            LOGGER.finer(() -> "no reason to block " + item.task);
+            return null;
+        }
+    }
+
+    private static final class HoldOnPlease extends CauseOfBlockage {
+        private final Queue.Task task;
+        HoldOnPlease(Queue.Task task) {
+            this.task = task;
+        }
+        @Override public String getShortDescription() {
+            return task.getFullDisplayName() + " should be allowed to run first";
+        }
+    }
+
+    public static void register(Node node, ContinuedTask task) throws IOException {
+        LOGGER.fine(() -> "registering " + task + " on " + node);
+        synchronized (node) {
+            var prop = node.getNodeProperty(UsageTracker.class);
+            List<ContinuedTask> tasks = prop != null ? new ArrayList<>(prop.tasks) : new ArrayList<>();
+            tasks.add(task);
+            node.getNodeProperties().replace(new UsageTracker(tasks));
+        }
+    }
+
+    public static void unregister(Node node, ContinuedTask task) throws IOException {
+        LOGGER.fine(() -> "unregistering " + task + " from " + node);
+        synchronized (node) {
+            var prop = node.getNodeProperty(UsageTracker.class);
+            if (prop != null) {
+                var tasks = new ArrayList<>(prop.tasks);
+                tasks.remove(task);
+                if (tasks.isEmpty()) {
+                    node.getNodeProperties().remove(UsageTracker.class);
+                } else {
+                    node.getNodeProperties().replace(new UsageTracker(tasks));
+                }
+            }
+        }
+    }
+
+    // TODO override reconfigure
+    // TODO use NodeListener.onUpdated to transfer TrackingProperty so that io.jenkins.plugins.casc.core.JenkinsConfigurator will not delete info from permanent agents
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepDynamicContextTest.java
@@ -265,7 +265,7 @@ public class ExecutorStepDynamicContextTest {
 
     @Test public void tardyResume() throws Throwable {
         commonSetup();
-        logging.record(ContinuedTask.class, Level.FINER);
+        logging.record(ContinuedTask.class, Level.FINER).record(UsageTracker.class, Level.FINER);
         sessions.then(j -> {
             j.createSlave("remote", "contended", null);
             var prompt = j.createProject(WorkflowJob.class, "prompt");


### PR DESCRIPTION
There seems to be a race condition with `ContinuedTask`: its effectiveness relies on the `PlaceholderTask` that was continued having actually been scheduled (and not merely in `pendings` but in `buildables`) by the time other tasks are added to the queue. That is not a safe assumption at least since https://github.com/jenkinsci/workflow-api-plugin/pull/221 (and possibly even before that), and certainly as of https://github.com/jenkinsci/workflow-api-plugin/pull/368 this is not a good basis for blocking queue items. I think it is necessary to somehow mark the `Slave` prior to shutdown as having been used for a given build, and wait for it to be ready before considering scheduling anything else onto the agent. ~(But not using anything in `config.xml`, since that would be clobbered by JCasC in the case of permanent agents.) Perhaps there is some simpler criterion that can be used.~

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-61733)